### PR TITLE
setup tax rate (Mails)

### DIFF
--- a/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
+++ b/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
@@ -48,5 +48,6 @@
         public bool IsSnapshotAfterMapChangeActive { get; set; } = false;
         public bool IsDamageMeterResetByMapChangeActive { get; set; } = false;
         public double MailMonitoringMarketTaxRate { get; set; } = 4;
+        public double MailMonitoringMarketTaxSetupRate { get; set; } = 2.5;
     }
 }

--- a/src/StatisticsAnalysisTool/Languages/de-DE.xml
+++ b/src/StatisticsAnalysisTool/Languages/de-DE.xml
@@ -657,4 +657,6 @@
 	<translation name="TOTAL_UNFINISHED_CRAFTING_WEIGHT">Gesamtesgewicht unfertige Herstellungen</translation>
 	<translation name="TOTAL_FINISHED_CRAFTING_WEIGHT">Gesamtesgewicht fertige Herstellungen</translation>
 	<translation name="MARKET_TAX_RATE">Marktsteuersatz</translation>
+	<translation name="MARKET_TAX_SETUP_RATE">Einstellungsgebührsatz</translation>
+	<translation name="SETUP_TAX">Einstellungsgebühr</translation>
 </translations>

--- a/src/StatisticsAnalysisTool/Languages/en-US.xml
+++ b/src/StatisticsAnalysisTool/Languages/en-US.xml
@@ -657,4 +657,6 @@
 	<translation name="TOTAL_UNFINISHED_CRAFTING_WEIGHT">Total unfinished crafting weight</translation>
 	<translation name="TOTAL_FINISHED_CRAFTING_WEIGHT">Total finished crafting weight</translation>
 	<translation name="MARKET_TAX_RATE">Market tax rate</translation>
+	<translation name="MARKET_TAX_SETUP_RATE">Market tax setup rate</translation>
+	<translation name="SETUP_TAX">Setup tax</translation>
 </translations>

--- a/src/StatisticsAnalysisTool/Languages/es-ES.xml
+++ b/src/StatisticsAnalysisTool/Languages/es-ES.xml
@@ -651,4 +651,15 @@
 	<translation name="TOTAL_LOOT_VALUE">Valor total looteado</translation>
 	<translation name="FILTER">Filtro</translation>
 	<translation name="LOOT_IN_SILVER">Loot en plata</translation>
+	<translation name="COMBAT_TIME">Tiempo de combate</translation>
+	<translation name="DELETE_ZERO_FAME_DUNGEONS">Eliminar mazmorras con 0 de fama</translation>
+	<translation name="SURE_YOU_WANT_TO_DELETE_ZERO_FAME_DUNGEONS">¿Estás seguro de querer eliminar las mazmorras con 0 de fama?</translation>
+	<translation name="TOTAL_RESOURCES_WEIGHT">Peso total de los recursos</translation>
+	<translation name="TOTAL_JOURNAL_WEIGHT">Peso total de los diarios</translation>
+	<translation name="TOTAL_CRAFTED_WEIGHT">Peso total de la fabricación</translation>
+	<translation name="TOTAL_UNFINISHED_CRAFTING_WEIGHT">Peso total pre-fabricación</translation>
+	<translation name="TOTAL_FINISHED_CRAFTING_WEIGHT">Peso total post-fabricación</translation>
+	<translation name="MARKET_TAX_RATE">Tasa de mercado</translation>
+	<translation name="MARKET_TAX_SETUP_RATE">Tasa de mercado (orden)</translation>
+	<translation name="SETUP_TAX">Tasa de mercado (orden)</translation>
 </translations>

--- a/src/StatisticsAnalysisTool/Models/Mail.cs
+++ b/src/StatisticsAnalysisTool/Models/Mail.cs
@@ -85,6 +85,8 @@ public class Mail : IComparable<Mail>, INotifyPropertyChanged
     public static string TranslationTotalRevenue => LanguageController.Translation("TOTAL_REVENUE");
     [JsonIgnore]
     public static string TranslationTax => LanguageController.Translation("TAX");
+    [JsonIgnore]
+    public static string TranslationSetupTax => LanguageController.Translation("SETUP_TAX");
     [JsonIgnore] 
     public static string TranslationSelectToDelete => LanguageController.Translation("SELECT_TO_DELETE");
     [JsonIgnore] 

--- a/src/StatisticsAnalysisTool/Models/MailOptionsObject.cs
+++ b/src/StatisticsAnalysisTool/Models/MailOptionsObject.cs
@@ -15,6 +15,7 @@ public class MailOptionsObject : INotifyPropertyChanged
     private DeleteMailsAfterDaysStruct _damageMeterSortSelection;
     private bool _ignoreMailsWithZeroValues;
     private double _marketTaxRate;
+    private double _marketTaxSetupRate;
 
     public MailOptionsObject()
     {
@@ -35,6 +36,7 @@ public class MailOptionsObject : INotifyPropertyChanged
         IsMailMonitoringActive = SettingsController.CurrentSettings.IsMailMonitoringActive;
         IgnoreMailsWithZeroValues = SettingsController.CurrentSettings.IgnoreMailsWithZeroValues;
         MarketTaxRate = SettingsController.CurrentSettings.MailMonitoringMarketTaxRate;
+        MarketTaxSetupRate = SettingsController.CurrentSettings.MailMonitoringMarketTaxSetupRate;
     }
 
     public bool IsMailMonitoringActive
@@ -90,10 +92,21 @@ public class MailOptionsObject : INotifyPropertyChanged
             OnPropertyChanged();
         }
     }
+    public double MarketTaxSetupRate
+    {
+        get => _marketTaxSetupRate;
+        set
+        {
+            _marketTaxSetupRate = value;
+            SettingsController.CurrentSettings.MailMonitoringMarketTaxSetupRate = _marketTaxSetupRate;
+            OnPropertyChanged();
+        }
+    }
 
     public static string TranslationMailMonitoringActive => LanguageController.Translation("MAIL_MONITORING_ACTIVE");
     public static string TranslationIgnoreMailsWithZeroValues => LanguageController.Translation("IGNORE_MAILS_WITH_ZERO_VALUES");
     public static string TranslationMarketTaxRate => LanguageController.Translation("MARKET_TAX_RATE");
+    public static string TranslationMarketTaxSetupRate => LanguageController.Translation("MARKET_TAX_SETUP_RATE");
     public static string TranslationSettings => LanguageController.Translation("SETTINGS");
 
     public event PropertyChangedEventHandler PropertyChanged;

--- a/src/StatisticsAnalysisTool/Models/MailStatsObject.cs
+++ b/src/StatisticsAnalysisTool/Models/MailStatsObject.cs
@@ -61,15 +61,15 @@ public class MailStatsObject : INotifyPropertyChanged
         BoughtMonth = mails.Where(x => x.Timestamp.Year == currentUtc.Year && x.Timestamp.Month == currentUtc.Month && x.MailType is MailType.MarketplaceBuyOrderFinished or MailType.MarketplaceBuyOrderExpired).Sum(x => x.MailContent.TotalPriceWithDeductedTaxes.IntegerValue);
         BoughtYear = mails.Where(x => x.Timestamp.Year == currentUtc.Year && x.MailType is MailType.MarketplaceBuyOrderFinished or MailType.MarketplaceBuyOrderExpired).Sum(x => x.MailContent.TotalPriceWithDeductedTaxes.IntegerValue);
 
-        TaxesToday = mails.Where(x => x.Timestamp.Date == DateTime.UtcNow.Date).Sum(x => x.MailContent.TaxPrice.IntegerValue);
-        TaxesThisWeek = mails.Where(x => x.Timestamp.IsDateInWeekOfYear(currentUtc)).Sum(x => x.MailContent.TaxPrice.IntegerValue);
-        TaxesLastWeek = mails.Where(x => x.Timestamp.IsDateInWeekOfYear(currentUtc.AddDays(-7))).Sum(x => x.MailContent.TaxPrice.IntegerValue);
-        TaxesMonth = mails.Where(x => x.Timestamp.Year == currentUtc.Year && x.Timestamp.Month == currentUtc.Month).Sum(x => x.MailContent.TaxPrice.IntegerValue);
-        TaxesYear = mails.Where(x => x.Timestamp.Year == currentUtc.Year).Sum(x => x.MailContent.TaxPrice.IntegerValue);
+        TaxesToday = mails.Where(x => x.Timestamp.Date == DateTime.UtcNow.Date).Sum(x => x.MailContent.TaxSetupPrice.IntegerValue + x.MailContent.TaxPrice.IntegerValue);
+        TaxesThisWeek = mails.Where(x => x.Timestamp.IsDateInWeekOfYear(currentUtc)).Sum(x => x.MailContent.TaxSetupPrice.IntegerValue + x.MailContent.TaxPrice.IntegerValue);
+        TaxesLastWeek = mails.Where(x => x.Timestamp.IsDateInWeekOfYear(currentUtc.AddDays(-7))).Sum(x => x.MailContent.TaxSetupPrice.IntegerValue + x.MailContent.TaxPrice.IntegerValue);
+        TaxesMonth = mails.Where(x => x.Timestamp.Year == currentUtc.Year && x.Timestamp.Month == currentUtc.Month).Sum(x => x.MailContent.TaxSetupPrice.IntegerValue + x.MailContent.TaxPrice.IntegerValue);
+        TaxesYear = mails.Where(x => x.Timestamp.Year == currentUtc.Year).Sum(x => x.MailContent.TaxSetupPrice.IntegerValue + x.MailContent.TaxPrice.IntegerValue);
 
         SoldTotal = mails.Where(x => x.MailType is MailType.MarketplaceSellOrderFinished or MailType.MarketplaceSellOrderExpired).Sum(x => x.MailContent.TotalPrice.IntegerValue);
         BoughtTotal = mails.Where(x => x.MailType is MailType.MarketplaceBuyOrderFinished or MailType.MarketplaceBuyOrderExpired).Sum(x => x.MailContent.TotalPrice.IntegerValue);
-        TaxesTotal = mails.Sum(x => x.MailContent.TaxPrice.IntegerValue);
+        TaxesTotal = mails.Sum(x => x.MailContent.TaxSetupPrice.IntegerValue + x.MailContent.TaxPrice.IntegerValue);
 
         SalesToday = SoldToday - (BoughtToday + TaxesToday);
         SalesThisWeek = SoldThisWeek - (BoughtThisWeek + TaxesThisWeek);

--- a/src/StatisticsAnalysisTool/Models/NetworkModel/MailContent.cs
+++ b/src/StatisticsAnalysisTool/Models/NetworkModel/MailContent.cs
@@ -11,6 +11,7 @@ public class MailContent
     public long InternalTotalPrice { get; set; }
     public long InternalUnitPrice { get; set; }
     public double TaxRate { get; set; } = 0;
+    public double TaxSetupRate { get; set; } = 0;
     [JsonIgnore]
     public bool IsTaxesStated => TaxRate > 0;
     [JsonIgnore]
@@ -23,10 +24,11 @@ public class MailContent
         : FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalTotalPrice).DoubleValue / UsedQuantity);
     [JsonIgnore]
     public FixPoint TaxPrice => FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalTotalPrice).DoubleValue / 100 * TaxRate);
+    public FixPoint TaxSetupPrice => FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalTotalPrice).DoubleValue / 100 * TaxSetupRate);
     [JsonIgnore]
-    public FixPoint TotalPriceWithDeductedTaxes => FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalTotalPrice).DoubleValue * ((100 - TaxRate) / 100));
+    public FixPoint TotalPriceWithDeductedTaxes => FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalTotalPrice).DoubleValue * ((100 - TaxRate - TaxSetupRate) / 100));
     [JsonIgnore]
-    public FixPoint UnitPriceWithDeductedTaxes => FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalUnitPrice).DoubleValue * ((100 - TaxRate) / 100));
+    public FixPoint UnitPriceWithDeductedTaxes => FixPoint.FromFloatingPointValue(FixPoint.FromInternalValue(InternalUnitPrice).DoubleValue * ((100 - TaxRate - TaxSetupRate) / 100));
     [JsonIgnore]
     public bool IsMailWithoutValues => InternalTotalPrice == 0 && UsedQuantity == 0;
 }

--- a/src/StatisticsAnalysisTool/Network/Manager/MailController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/MailController.cs
@@ -63,7 +63,7 @@ namespace StatisticsAnalysisTool.Network.Manager
                 return;
             }
             
-            var mailContent = ContentToObject(mailInfo.MailType, content, SettingsController.CurrentSettings.MailMonitoringMarketTaxRate);
+            var mailContent = ContentToObject(mailInfo.MailType, content, SettingsController.CurrentSettings.MailMonitoringMarketTaxRate, SettingsController.CurrentSettings.MailMonitoringMarketTaxSetupRate);
 
             if (SettingsController.CurrentSettings.IgnoreMailsWithZeroValues && mailContent.IsMailWithoutValues)
             {
@@ -135,7 +135,7 @@ namespace StatisticsAnalysisTool.Network.Manager
             });
         }
 
-        private static MailContent ContentToObject(MailType type, string content, double taxRate)
+        private static MailContent ContentToObject(MailType type, string content, double taxRate, double taxSetupRate)
         {
             switch (type)
             {
@@ -162,7 +162,8 @@ namespace StatisticsAnalysisTool.Network.Manager
                             InternalTotalPrice = totalPriceLong,
                             InternalUnitPrice = unitPriceLong,
                             UniqueItemName = uniqueItemName,
-                            TaxRate = taxRate
+                            TaxRate = taxRate,
+                            TaxSetupRate = taxSetupRate
                         };
                     }
 
@@ -172,7 +173,8 @@ namespace StatisticsAnalysisTool.Network.Manager
                         Quantity = quantity,
                         InternalTotalPrice = totalPriceLong,
                         InternalUnitPrice = unitPriceLong,
-                        UniqueItemName = uniqueItemName
+                        UniqueItemName = uniqueItemName,
+                        TaxSetupRate = taxSetupRate
                     };
                 case MailType.MarketplaceSellOrderExpired:
                 case MailType.MarketplaceBuyOrderExpired:
@@ -204,7 +206,8 @@ namespace StatisticsAnalysisTool.Network.Manager
                             InternalTotalPrice = FixPoint.FromFloatingPointValue(totalPrice).InternalValue,
                             InternalUnitPrice = FixPoint.FromFloatingPointValue(singlePrice).InternalValue,
                             UniqueItemName = uniqueItemExpiredName,
-                            TaxRate = taxRate
+                            TaxRate = taxRate,
+                            TaxSetupRate = taxSetupRate
                         };
                     }
 
@@ -214,7 +217,8 @@ namespace StatisticsAnalysisTool.Network.Manager
                         Quantity = expiredQuantity,
                         InternalTotalPrice = FixPoint.FromFloatingPointValue(totalPrice).InternalValue,
                         InternalUnitPrice = FixPoint.FromFloatingPointValue(singlePrice).InternalValue,
-                        UniqueItemName = uniqueItemExpiredName
+                        UniqueItemName = uniqueItemExpiredName,
+                        TaxSetupRate = taxSetupRate
                     };
                 default:
                     return new MailContent();
@@ -235,9 +239,15 @@ namespace StatisticsAnalysisTool.Network.Manager
 
                     // The if block convert data from old versions to new version
                     if (item.MailType is MailType.MarketplaceSellOrderFinished or MailType.MarketplaceSellOrderExpired
-                        && item.MailContent?.TaxRate != null && !item.MailContent.TaxRate.Equals(3) && item.Timestamp < new DateTime(2022, 12, 1))
+                        && item.MailContent?.TaxRate != null && item.Timestamp < new DateTime(2022, 12, 1))
                     {
-                        item.MailContent.TaxRate = 3;
+                        item.MailContent.TaxRate = item.Timestamp < new DateTime(2022, 9, 14) ? 3 : 4; // Into the Fray Patch 6 tax increase
+                    }
+
+                    // The if block convert data from old versions to new version
+                    if (item.MailContent?.TaxSetupRate != null && item.Timestamp < new DateTime(2022, 12, 1))
+                    {
+                        item.MailContent.TaxSetupRate = item.Timestamp < new DateTime(2022, 9, 14) ? 1.5 : 2.5; // Into the Fray Patch 6 tax increase
                     }
                 }
 

--- a/src/StatisticsAnalysisTool/Styles/MailMonitoringStyle.xaml
+++ b/src/StatisticsAnalysisTool/Styles/MailMonitoringStyle.xaml
@@ -436,8 +436,8 @@
                         </DockPanel>
                         <DockPanel>
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="{Binding TranslationCostPerItem, IsAsync=True}" Width="200" Foreground="{StaticResource SolidColorBrush.Text.4}" />
-                                <TextBlock Text="{Binding TranslationTotalCost, IsAsync=True, FallbackValue=TOTAL_COST}" Width="200" Foreground="{StaticResource SolidColorBrush.Text.4}">
+                                <TextBlock Text="{Binding TranslationCostPerItem, IsAsync=True}" Width="160" Foreground="{StaticResource SolidColorBrush.Text.4}" />
+                                <TextBlock Text="{Binding TranslationTotalCost, IsAsync=True, FallbackValue=TOTAL_COST}" Width="160" Foreground="{StaticResource SolidColorBrush.Text.4}">
                                     <TextBlock.Style>
                                         <Style TargetType="{x:Type TextBlock}">
                                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -458,7 +458,7 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
-                                <TextBlock Text="{Binding TranslationTotalRevenue, IsAsync=True, FallbackValue=TOTAL_REVENUE}" Width="200" Foreground="{StaticResource SolidColorBrush.Text.4}">
+                                <TextBlock Text="{Binding TranslationTotalRevenue, IsAsync=True, FallbackValue=TOTAL_REVENUE}" Width="160" Foreground="{StaticResource SolidColorBrush.Text.4}">
                                     <TextBlock.Style>
                                         <Style TargetType="{x:Type TextBlock}">
                                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -479,7 +479,7 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
-                                <TextBlock Width="200" Foreground="{StaticResource SolidColorBrush.Text.4}">
+                                <TextBlock Width="160" Foreground="{StaticResource SolidColorBrush.Text.4}">
                                     <TextBlock.Text>
                                         <MultiBinding StringFormat="{}{0} ({1}%)">
                                             <Binding Path="TranslationSetupTax" IsAsync="True" />
@@ -487,7 +487,7 @@
                                         </MultiBinding>
                                     </TextBlock.Text>
                                 </TextBlock>
-                                <TextBlock Width="150" Foreground="{StaticResource SolidColorBrush.Text.4}">
+                                <TextBlock Width="110" Foreground="{StaticResource SolidColorBrush.Text.4}">
                                     <TextBlock.Style>
                                         <Style TargetType="{x:Type TextBlock}">
                                             <Setter Property="Visibility" Value="Collapsed"/>
@@ -513,22 +513,22 @@
                         </DockPanel>
                         <DockPanel>
                             <StackPanel Orientation="Horizontal">
-                                <Grid Width="200">
+                                <Grid Width="160">
                                     <Image Style="{StaticResource Mail.Image.Style}" ToolTip="{Binding TranslationSilver, IsAsync=True}" />
                                     <TextBlock Text="{common:CultureAwareBinding MailContent.ActualUnitPrice.DoubleValue, IsAsync=True, StringFormat='{}{0:N0}', FallbackValue=0}" 
                                            Style="{StaticResource Mail.Text.Colors}" Margin="25,0,0,0" />
                                 </Grid>
-                                <Grid Width="200">
+                                <Grid Width="160">
                                     <Image Style="{StaticResource Mail.Image.Style}" ToolTip="{Binding TranslationSilver, IsAsync=True}" />
                                     <TextBlock Text="{common:CultureAwareBinding MailContent.TotalPriceWithDeductedTaxes.DoubleValue, IsAsync=True, StringFormat='{}{0:N0}', FallbackValue=0}" 
                                            Style="{StaticResource Mail.Text.Colors}" Margin="25,0,0,0" ToolTip="{Binding MailContent.TotalPrice}" />
                                 </Grid>
-                                <Grid Width="200">
+                                <Grid Width="160">
                                     <Image Style="{StaticResource Mail.Image.Style}" ToolTip="{Binding TranslationSilver, IsAsync=True}" />
                                     <TextBlock Text="{common:CultureAwareBinding MailContent.TaxSetupPrice.DoubleValue, IsAsync=True, StringFormat='{}{0:N0}', FallbackValue=0}" 
                                                HorizontalAlignment="Left" Foreground="{StaticResource SolidColorBrush.Accent.Red.3}" Margin="25,0,0,0" />
                                 </Grid>
-                                <Grid Width="200">
+                                <Grid Width="110">
                                     <Grid.Style>
                                         <Style TargetType="{x:Type Grid}">
                                             <Setter Property="Visibility" Value="Collapsed"/>

--- a/src/StatisticsAnalysisTool/Styles/MailMonitoringStyle.xaml
+++ b/src/StatisticsAnalysisTool/Styles/MailMonitoringStyle.xaml
@@ -368,6 +368,11 @@
                         <Label Content="{Binding TranslationMarketTaxRate, FallbackValue=MARKET__TAX__RATE}" MinWidth="300" VerticalAlignment="Top" />
                     </StackPanel>
 
+                    <StackPanel Orientation="Horizontal">
+                        <TextBox Text="{Binding MarketTaxSetupRate}" Width="25" Height="20"  Margin="5,-2,0,0" common:TextBoxHelper.OnlyNumeric="Double" />
+                        <Label Content="{Binding TranslationMarketTaxSetupRate, FallbackValue=MARKET__TAX__SETUP__RATE}" MinWidth="300" VerticalAlignment="Top" />
+                    </StackPanel>
+
                     <ComboBox Width="200" Height="26" Margin="0,5,0,5" ItemsSource="{Binding DeleteMailsOlderThanSpecifiedDays}" 
                               SelectedItem="{Binding DeleteMailsOlderThanSpecifiedDaysSelection, IsAsync=true}" 
                               HorizontalAlignment="Left" DisplayMemberPath="Name" SelectedValuePath="Days" />
@@ -474,6 +479,14 @@
                                         </Style>
                                     </TextBlock.Style>
                                 </TextBlock>
+                                <TextBlock Width="200" Foreground="{StaticResource SolidColorBrush.Text.4}">
+                                    <TextBlock.Text>
+                                        <MultiBinding StringFormat="{}{0} ({1}%)">
+                                            <Binding Path="TranslationSetupTax" IsAsync="True" />
+                                            <Binding Path="MailContent.TaxSetupRate" IsAsync="True" />
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
                                 <TextBlock Width="150" Foreground="{StaticResource SolidColorBrush.Text.4}">
                                     <TextBlock.Style>
                                         <Style TargetType="{x:Type TextBlock}">
@@ -509,6 +522,11 @@
                                     <Image Style="{StaticResource Mail.Image.Style}" ToolTip="{Binding TranslationSilver, IsAsync=True}" />
                                     <TextBlock Text="{common:CultureAwareBinding MailContent.TotalPriceWithDeductedTaxes.DoubleValue, IsAsync=True, StringFormat='{}{0:N0}', FallbackValue=0}" 
                                            Style="{StaticResource Mail.Text.Colors}" Margin="25,0,0,0" ToolTip="{Binding MailContent.TotalPrice}" />
+                                </Grid>
+                                <Grid Width="200">
+                                    <Image Style="{StaticResource Mail.Image.Style}" ToolTip="{Binding TranslationSilver, IsAsync=True}" />
+                                    <TextBlock Text="{common:CultureAwareBinding MailContent.TaxSetupPrice.DoubleValue, IsAsync=True, StringFormat='{}{0:N0}', FallbackValue=0}" 
+                                               HorizontalAlignment="Left" Foreground="{StaticResource SolidColorBrush.Accent.Red.3}" Margin="25,0,0,0" />
                                 </Grid>
                                 <Grid Width="200">
                                     <Grid.Style>


### PR DESCRIPTION
- Added market setup tax to mail tracking, totals and config.
- Fixed taxes to +1% ([Into the Fray Patch 6 tax updates](https://albiononline.com/en/changelog/into-the-fray-patch-6))
- Few translations
<br/>
Btw, I think SetMailsAsync would override stored values in Mail.json ignoring any different rate set by users on the tax & setup tax rate configs until 2022-12-1. But at least after adding the fixed 1% they would be ok, (for premium users).

<br/>
<br/>

_After disappearing a lot of time after proposing that mail tracking implementation, I've come back to at least contribute a bit._