### PR TITLE
Fix mobs.json can not be loaded

### DIFF
--- a/src/StatisticsAnalysisTool/GameData/MobsData.cs
+++ b/src/StatisticsAnalysisTool/GameData/MobsData.cs
@@ -91,7 +91,10 @@ public static class MobsData
             }
 
             var fullMobsJson = GetDataFromFullJsonFileLocal(tempFilePath);
-            await FileController.SaveAsync(fullMobsJson, regularDataFilePath);
+            if(fullMobsJson.Count() > 1)
+            {
+                await FileController.SaveAsync(fullMobsJson, regularDataFilePath);
+            }
         }
 
         _mobs = GetSpecificDataFromJsonFileLocal(regularDataFilePath);


### PR DESCRIPTION
If mobs.json is not read correctly when opening the StatisticsAnalysisTool.exe(internet connection error), and the code is still wrongly written into mobs-modified.json, it will always display mobs.json can not be loaded, so when mobs.json is not read correctly We should not write to mobs-modified.json