### PR TITLE
Fixed dungeon tier offset on display

### DIFF
--- a/src/StatisticsAnalysisTool/Dungeon/DungeonNotificationFragment.cs
+++ b/src/StatisticsAnalysisTool/Dungeon/DungeonNotificationFragment.cs
@@ -216,10 +216,10 @@ public class DungeonNotificationFragment : LineFragment, INotifyPropertyChanged
         var levelString = level switch
         {
             0 => "",
-            1 => ".0",
-            2 => ".1",
-            3 => ".2",
-            4 => ".3",
+            1 => ".1",
+            2 => ".2",
+            3 => ".3",
+            4 => ".4",
             _ => ".?"
         };
 


### PR DESCRIPTION
Refer to the issue [#350 ](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/issues/350)
