### PR TITLE
Fixed DirectoryNotFoundException

### DIFF
--- a/src/StatisticsAnalysisTool/EstimatedMarketValue/EstimatedMarketValueController.cs
+++ b/src/StatisticsAnalysisTool/EstimatedMarketValue/EstimatedMarketValueController.cs
@@ -132,6 +132,7 @@ public static class EstimatedMarketValueController
 
     public static async Task SaveInFileAsync()
     {
+        DirectoryController.CreateDirectoryWhenNotExists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName));
         await FileController.SaveAsync(_estimatedMarketValueObjects.ToList().Select(EstimatesMarketValueMapping.Mapping),
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName, Settings.Default.EstimatedMarketValueFileName));
         Debug.Print("Estimated market values saved");

--- a/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
@@ -273,6 +273,7 @@ public class StatisticController
 
     public async Task SaveInFileAsync()
     {
+        DirectoryController.CreateDirectoryWhenNotExists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName));
         await FileController.SaveAsync(_dashboardStatistics, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName, Settings.Default.StatsFileName));
         Debug.Print("Statistics saved");
     }

--- a/src/StatisticsAnalysisTool/Network/Manager/TreasureController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/TreasureController.cs
@@ -292,6 +292,7 @@ public class TreasureController
 
     public async Task SaveInFileAsync()
     {
+        DirectoryController.CreateDirectoryWhenNotExists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName));
         await FileController.SaveAsync(_treasures, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName, Settings.Default.TreasureStatsFileName));
         Debug.Print("Treasure saved");
     }

--- a/src/StatisticsAnalysisTool/Network/Manager/VaultController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/VaultController.cs
@@ -331,6 +331,7 @@ public class VaultController
 
     public async Task SaveInFileAsync()
     {
+        DirectoryController.CreateDirectoryWhenNotExists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName));
         await FileController.SaveAsync(Vaults, Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName, Settings.Default.VaultsFileName));
         Debug.Print("Vault saved");
     }


### PR DESCRIPTION
Error may occur when saving a file if the UserData folder doesn't exist