### PR TITLE
Add Europe Server

### DIFF
--- a/src/StatisticsAnalysisTool/App.xaml.cs
+++ b/src/StatisticsAnalysisTool/App.xaml.cs
@@ -52,7 +52,8 @@ public partial class App
         }
 
         if (SettingsController.CurrentSettings.ServerLocation != ServerLocation.West
-            && SettingsController.CurrentSettings.ServerLocation != ServerLocation.East)
+            && SettingsController.CurrentSettings.ServerLocation != ServerLocation.East
+            && SettingsController.CurrentSettings.ServerLocation != ServerLocation.Europe)
         {
             Server.SetServerLocationWithDialogAsync();
         }

--- a/src/StatisticsAnalysisTool/Common/ApiController.cs
+++ b/src/StatisticsAnalysisTool/Common/ApiController.cs
@@ -560,6 +560,7 @@ public static class ApiController
         {
             ServerLocation.West => SettingsController.CurrentSettings.AlbionDataProjectBaseUrlWest,
             ServerLocation.East => SettingsController.CurrentSettings.AlbionDataProjectBaseUrlEast,
+            ServerLocation.Europe => SettingsController.CurrentSettings.AlbionDataProjectBaseUrlEurope,
             _ => SettingsController.CurrentSettings.AlbionDataProjectBaseUrlWest
         };
     }
@@ -570,6 +571,7 @@ public static class ApiController
         {
             ServerLocation.West => SettingsController.CurrentSettings.AlbionOnlineApiBaseUrlWest,
             ServerLocation.East => SettingsController.CurrentSettings.AlbionOnlineApiBaseUrlEast,
+            ServerLocation.Europe => SettingsController.CurrentSettings.AlbionOnlineApiBaseUrlEurope,
             _ => SettingsController.CurrentSettings.AlbionOnlineApiBaseUrlWest
         };
     }

--- a/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
+++ b/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
@@ -12,7 +12,7 @@ public class SettingsObject
 {
     public string CurrentCultureIetfLanguageTag { get; set; }
     public int RefreshRate { get; set; } = 10000;
-    public string PacketFilter { get; set; } = "(host 5.45.187 or host 5.188.125) and udp port 5056";
+    public string PacketFilter { get; set; } = "(host 5.45.187 or host 5.188.125 or 193.169.238) and udp port 5056";
     public PacketProviderKind PacketProvider { get; set; } = PacketProviderKind.Sockets;
     public ServerLocation ServerLocation { get; set; } = 0; // 0: auto, 1: west, 2: east
     public ServerType ServerType { get; set; } = ServerType.Live; // 0: Live, 1: Staging, 2: Playground
@@ -24,8 +24,10 @@ public class SettingsObject
     public string SelectedAlertSound { get; set; }
     public string AlbionDataProjectBaseUrlWest { get; set; } = "https://albion-online-data.com/api/v2/";
     public string AlbionDataProjectBaseUrlEast { get; set; } = "https://east.albion-online-data.com/api/v2/";
+    public string AlbionDataProjectBaseUrlEurope { get; set; } = "https://europe.albion-online-data.com/api/v2/";
     public string AlbionOnlineApiBaseUrlWest { get; set; } = "https://gameinfo.albiononline.com";
     public string AlbionOnlineApiBaseUrlEast { get; set; } = "https://gameinfo-sgp.albiononline.com";
+    public string AlbionOnlineApiBaseUrlEurope { get; set; } = ""; // TODO: URL still unknown
     public double MainWindowHeight { get; set; } = 100;
     public double MainWindowWidth { get; set; } = 100;
     public double MainWindowLeftPosition { get; set; } = 0;

--- a/src/StatisticsAnalysisTool/Enumerations/ServerLocation.cs
+++ b/src/StatisticsAnalysisTool/Enumerations/ServerLocation.cs
@@ -4,5 +4,6 @@ public enum ServerLocation
 {
     Unknown = 0,
     West = 1,
-    East = 2
+    East = 2,
+    Europe = 3
 }

--- a/src/StatisticsAnalysisTool/Languages/de-DE.xml
+++ b/src/StatisticsAnalysisTool/Languages/de-DE.xml
@@ -662,10 +662,12 @@
 	<translation name="NAVIGATION_TAB_VISIBILITY">Navigation Tab Sichtbarkeit</translation>
 	<translation name="SERVER">Server</translation>
 	<translation name="UNKNOWN_SERVER">Unbekannter Server</translation>
-	<translation name="WEST_SERVER">West Server</translation>
-	<translation name="EAST_SERVER">Ost Server</translation>
+	<translation name="WEST_SERVER">Amerikas Server</translation>
+	<translation name="EAST_SERVER">Asien Server</translation>
+	<translation name="EUROPE_SERVER">Europa Server</translation>
 	<translation name="ALBION_DATA_PROJECT_BASE_URL_WEST">Albion data project base url WEST</translation>
 	<translation name="ALBION_DATA_PROJECT_BASE_URL_EAST">Albion data project base url OST</translation>
+	<translation name="ALBION_DATA_PROJECT_BASE_URL_EUROPE">Albion data project base url EUROPE</translation>
 	<translation name="DELETE_ALL_SNAPSHOTS">Alle Snapshots löschen</translation>
 	<translation name="SURE_YOU_WANT_TO_DELETE_ALL_SNAPSHOTS">Wirklich alle Snapshots löschen?</translation>
 	<translation name="LOGGING_DESCRIPTION_1">Wenn falsche Items getrackt werden, kann das daran liegen, dass die Item listen nicht aktuell sind. Die URL's dafür können in den Settings angepasst werden.</translation>

--- a/src/StatisticsAnalysisTool/Languages/en-US.xml
+++ b/src/StatisticsAnalysisTool/Languages/en-US.xml
@@ -662,10 +662,12 @@
 	<translation name="NAVIGATION_TAB_VISIBILITY">Navigation tab visibility</translation>
 	<translation name="SERVER">Server</translation>
 	<translation name="UNKNOWN_SERVER">Unknown Server</translation>
-	<translation name="WEST_SERVER">West Server</translation>
-	<translation name="EAST_SERVER">East Server</translation>
+	<translation name="WEST_SERVER">Americas Server</translation>
+	<translation name="EAST_SERVER">Asia Server</translation>
+	<translation name="EUROPE_SERVER">Europe Server</translation>
 	<translation name="ALBION_DATA_PROJECT_BASE_URL_WEST">Albion data project base url WEST</translation>
 	<translation name="ALBION_DATA_PROJECT_BASE_URL_EAST">Albion data project base url EAST</translation>
+	<translation name="ALBION_DATA_PROJECT_BASE_URL_EUROPE">Albion data project base url EUROPE</translation>
 	<translation name="DELETE_ALL_SNAPSHOTS">Delete all snapshots</translation>
 	<translation name="SURE_YOU_WANT_TO_DELETE_ALL_SNAPSHOTS">Are you sure you want to delete all snapshots?</translation>
 	<translation name="LOGGING_DESCRIPTION_1">If incorrect items are tracked, it may be because the item lists are not up to date. The URLs for this can be adjusted in the settings.</translation>

--- a/src/StatisticsAnalysisTool/Models/TranslationModel/SettingsWindowTranslation.cs
+++ b/src/StatisticsAnalysisTool/Models/TranslationModel/SettingsWindowTranslation.cs
@@ -20,6 +20,7 @@ public class SettingsWindowTranslation
     public static string CreateDesktopShortcut => LanguageController.Translation("CREATE_DESKTOP_SHORTCUT");
     public static string AlbionDataProjectBaseUrlWest => LanguageController.Translation("ALBION_DATA_PROJECT_BASE_URL_WEST");
     public static string AlbionDataProjectBaseUrlEast => LanguageController.Translation("ALBION_DATA_PROJECT_BASE_URL_EAST");
+    public static string AlbionDataProjectBaseUrlEurope => LanguageController.Translation("ALBION_DATA_PROJECT_BASE_URL_EUROPE");
     public static string GoldStatsApiUrl => LanguageController.Translation("GOLD_STATS_API_URL");
     public static string IsLootLoggerSaveReminderActive => LanguageController.Translation("IS_LOOT_LOGGER_SAVE_REMINDER_ACTIVE");
     public static string ExportLootLoggingFileWithRealItemName => LanguageController.Translation("EXPORT_LOOT_LOGGING_FILE_WITH_REAL_ITEM_NAME");
@@ -35,6 +36,7 @@ public class SettingsWindowTranslation
     public static string Automatically => LanguageController.Translation("AUTOMATICALLY");
     public static string WestServer => LanguageController.Translation("WEST_SERVER");
     public static string EastServer => LanguageController.Translation("EAST_SERVER");
+    public static string EuropeServer => LanguageController.Translation("EUROPE_SERVER");
     public static string Activated => LanguageController.Translation("ACTIVATED");
     public static string Disabled => LanguageController.Translation("DISABLED");
     public static string Notifications => LanguageController.Translation("NOTIFICATIONS");

--- a/src/StatisticsAnalysisTool/UserControls/SettingsControl.xaml
+++ b/src/StatisticsAnalysisTool/UserControls/SettingsControl.xaml
@@ -120,6 +120,10 @@
                         <Label Content="{Binding Translation.AlbionDataProjectBaseUrlEast, FallbackValue=ALBION_DATA_PROJECT_BASE_URL_EAST}" MinWidth="300" VerticalAlignment="Top" />
                         <TextBox Text="{Binding AlbionDataProjectBaseUrlEast}" Height="40" TextWrapping="Wrap" VerticalAlignment="Top" Margin="0,0,5,0" />
                     </DockPanel>
+                    <DockPanel Margin="0,5,0,0">
+                        <Label Content="{Binding Translation.AlbionDataProjectBaseUrlEurope, FallbackValue=ALBION_DATA_PROJECT_BASE_URL_EUROPE}" MinWidth="300" VerticalAlignment="Top" />
+                        <TextBox Text="{Binding AlbionDataProjectBaseUrlEurope}" Height="40" TextWrapping="Wrap" VerticalAlignment="Top" Margin="0,0,5,0" />
+                    </DockPanel>
 
                     <!-- Item window -->
                     <DockPanel Margin="0,20,0,0">

--- a/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
+++ b/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
@@ -330,6 +330,7 @@ public class MainWindowViewModel : BaseViewModel
         {
             ServerLocation.East => LanguageController.Translation("EAST_SERVER"),
             ServerLocation.West => LanguageController.Translation("WEST_SERVER"),
+            ServerLocation.Europe => LanguageController.Translation("EUROPE_SERVER"),
             _ => LanguageController.Translation("UNKNOWN_SERVER")
         };
     }

--- a/src/StatisticsAnalysisTool/ViewModels/ServerLocationSelectionWindowViewModel.cs
+++ b/src/StatisticsAnalysisTool/ViewModels/ServerLocationSelectionWindowViewModel.cs
@@ -30,6 +30,11 @@ public class ServerLocationSelectionWindowViewModel : BaseViewModel
             {
                 Name = LanguageController.Translation("EAST_SERVER"),
                 ServerLocation = ServerLocation.East
+            },
+            new ()
+            {
+                Name = LanguageController.Translation("EUROPE_SERVER"),
+                ServerLocation = ServerLocation.Europe
             }
         };
 

--- a/src/StatisticsAnalysisTool/ViewModels/SettingsWindowViewModel.cs
+++ b/src/StatisticsAnalysisTool/ViewModels/SettingsWindowViewModel.cs
@@ -35,6 +35,7 @@ public class SettingsWindowViewModel : BaseViewModel
     private SettingsWindowTranslation _translation;
     private string _albionDataProjectBaseUrlWest;
     private string _albionDataProjectBaseUrlEast;
+    private string _albionDataProjectBaseUrlEurope;
     private ObservableCollection<SettingDataInformation> _backupIntervalByDays = new();
     private ObservableCollection<SettingDataInformation> _maximumNumberOfBackups = new();
     private bool _isSuggestPreReleaseUpdatesActive;
@@ -88,6 +89,7 @@ public class SettingsWindowViewModel : BaseViewModel
         // Api urls
         AlbionDataProjectBaseUrlWest = SettingsController.CurrentSettings.AlbionDataProjectBaseUrlWest;
         AlbionDataProjectBaseUrlEast = SettingsController.CurrentSettings.AlbionDataProjectBaseUrlEast;
+        AlbionDataProjectBaseUrlEurope = SettingsController.CurrentSettings.AlbionDataProjectBaseUrlEurope;
 
         // Auto update
         IsSuggestPreReleaseUpdatesActive = SettingsController.CurrentSettings.IsSuggestPreReleaseUpdatesActive;
@@ -193,7 +195,7 @@ public class SettingsWindowViewModel : BaseViewModel
 
     public void ResetPacketFilter()
     {
-        const string defaultFilter = "(host 5.45.187 or host 5.188.125) and udp port 5056";
+        const string defaultFilter = "(host 5.45.187 or host 5.188.125 or 193.169.238) and udp port 5056";
 
         if (PacketFilter == defaultFilter)
         {
@@ -431,6 +433,7 @@ public class SettingsWindowViewModel : BaseViewModel
         Server.Clear();
         Server.Add(new SettingDataInformation { Name = SettingsWindowTranslation.WestServer, Value = 1 });
         Server.Add(new SettingDataInformation { Name = SettingsWindowTranslation.EastServer, Value = 2 });
+        Server.Add(new SettingDataInformation { Name = SettingsWindowTranslation.EuropeServer, Value = 3 });
         ServerSelection = Server.FirstOrDefault(x => x.Value == (int) SettingsController.CurrentSettings.ServerLocation);
     }
 
@@ -729,6 +732,16 @@ public class SettingsWindowViewModel : BaseViewModel
         set
         {
             _albionDataProjectBaseUrlEast = value;
+            OnPropertyChanged();
+        }
+    }
+    
+    public string AlbionDataProjectBaseUrlEurope
+    {
+        get => _albionDataProjectBaseUrlEurope;
+        set
+        {
+            _albionDataProjectBaseUrlEurope = value;
             OnPropertyChanged();
         }
     }

--- a/src/StatisticsAnalysisTool/Views/ServerLocationSelectionWindow.xaml.cs
+++ b/src/StatisticsAnalysisTool/Views/ServerLocationSelectionWindow.xaml.cs
@@ -35,7 +35,7 @@ public partial class ServerLocationSelectionWindow
 
     private void BtnConfirm_Click(object sender, RoutedEventArgs e)
     {
-        if (_serverLocationSelectionWindowViewModel.SelectedServerLocation.ServerLocation is not (ServerLocation.West or ServerLocation.East))
+        if (_serverLocationSelectionWindowViewModel.SelectedServerLocation.ServerLocation is not (ServerLocation.West or ServerLocation.East or ServerLocation.Europe))
         {
             return;
         }


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] This is not a **[duplicate](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] All new and existing tests pass.

## Changes

### New functionality
Adds support for the new europe server

### Changed functionality
Renamed West -> Americas and East -> Asia in German and English translation to reflect SBI naming.

## Additional info

The gameinfo endpoint for europe is still missing so we have to wait for the official launch.