### PR TITLE
new setting that allows for damage meters to track non party members

### DIFF
--- a/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
+++ b/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
@@ -63,6 +63,7 @@ public class SettingsObject
     public bool IsSnapshotAfterMapChangeActive { get; set; }
     public bool IsDamageMeterResetByMapChangeActive { get; set; }
     public bool IsDamageMeterResetBeforeCombatActive { get; set; }
+    public bool IsDamageMeterNonPartyTrackingActive { get; set; }
     public double TradeMonitoringMarketTaxRate { get; set; } = 4;
     public double TradeMonitoringMarketTaxSetupRate { get; set; } = 2.5;
     public bool IsDungeonClosedSoundActive { get; set; }

--- a/src/StatisticsAnalysisTool/DamageMeter/DamageMeterBindings.cs
+++ b/src/StatisticsAnalysisTool/DamageMeter/DamageMeterBindings.cs
@@ -31,6 +31,7 @@ public class DamageMeterBindings : BaseViewModel, IAsyncInitialization
     private bool _isSnapshotAfterMapChangeActive;
     private GridLength _gridSplitterPosition;
     private bool _isDamageMeterResetBeforeCombatActive;
+    private bool _isDamageMeterNonPartyTrackingActive;
     private bool _shortDamageMeterToClipboard;
     public Task Initialization { get; init; }
 
@@ -81,6 +82,7 @@ public class DamageMeterBindings : BaseViewModel, IAsyncInitialization
         IsSnapshotAfterMapChangeActive = SettingsController.CurrentSettings.IsSnapshotAfterMapChangeActive;
         IsDamageMeterResetByMapChangeActive = SettingsController.CurrentSettings.IsDamageMeterResetByMapChangeActive;
         IsDamageMeterResetBeforeCombatActive = SettingsController.CurrentSettings.IsDamageMeterResetBeforeCombatActive;
+        IsDamageMeterNonPartyTrackingActive = SettingsController.CurrentSettings.IsDamageMeterNonPartyTrackingActive;
         ShortDamageMeterToClipboard = SettingsController.CurrentSettings.ShortDamageMeterToClipboard;
 
         Initialization = LoadLocalFileAsync();
@@ -207,6 +209,17 @@ public class DamageMeterBindings : BaseViewModel, IAsyncInitialization
         {
             _isDamageMeterResetBeforeCombatActive = value;
             SettingsController.CurrentSettings.IsDamageMeterResetBeforeCombatActive = _isDamageMeterResetBeforeCombatActive;
+            OnPropertyChanged();
+        }
+    }
+
+    public bool IsDamageMeterNonPartyTrackingActive
+    {
+        get => _isDamageMeterNonPartyTrackingActive;
+        set
+        {
+            _isDamageMeterNonPartyTrackingActive = value;
+            SettingsController.CurrentSettings.IsDamageMeterNonPartyTrackingActive = _isDamageMeterNonPartyTrackingActive;
             OnPropertyChanged();
         }
     }

--- a/src/StatisticsAnalysisTool/Languages/de-DE.xml
+++ b/src/StatisticsAnalysisTool/Languages/de-DE.xml
@@ -620,6 +620,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Reparaturkosten die letzten 7 Tage</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Reparaturkosten die letzten 30 Tage</translation>
 	<translation name="RESET_BEFORE_COMBAT">Vor Kampf zurücksetzen</translation>
+	<translation name="NON_PARTY_TRACKING">Nicht-Parteimitglieder einbeziehen</translation>
 	<translation name="SEARCHED_PLAYER">Gesuchter Spieler</translation>
 	<translation name="LOCAL_PLAYER">Lokaler Spieler</translation>
 	<translation name="THANKS">Danke</translation>

--- a/src/StatisticsAnalysisTool/Languages/en-US.xml
+++ b/src/StatisticsAnalysisTool/Languages/en-US.xml
@@ -620,6 +620,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Repair costs last 7 days</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Repair costs last 30 days</translation>
 	<translation name="RESET_BEFORE_COMBAT">Reset before combat</translation>
+	<translation name="NON_PARTY_TRACKING">Include non-party members</translation>
 	<translation name="SEARCHED_PLAYER">Searched player</translation>
 	<translation name="LOCAL_PLAYER">Local player</translation>
 	<translation name="THANKS">Thanks</translation>

--- a/src/StatisticsAnalysisTool/Languages/es-ES.xml
+++ b/src/StatisticsAnalysisTool/Languages/es-ES.xml
@@ -659,7 +659,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Costes de reparación los últimos 7 días</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Costes de reparación los últimos 30 días</translation>
 	<translation name="RESET_BEFORE_COMBAT">Reiniciar antes de combate</translation>
-	<translation name="NON_PARTY_TRACKING">Incluir a miembros no partidistas</translation>
+	<translation name="NON_PARTY_TRACKING">A los que no son miembros del partido</translation>
 	<translation name="SEARCHED_PLAYER">Jugador buscado</translation>
 	<translation name="LOCAL_PLAYER">Jugador local</translation>
 	<translation name="THANKS">Agradecimientos</translation>

--- a/src/StatisticsAnalysisTool/Languages/es-ES.xml
+++ b/src/StatisticsAnalysisTool/Languages/es-ES.xml
@@ -659,7 +659,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Costes de reparación los últimos 7 días</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Costes de reparación los últimos 30 días</translation>
 	<translation name="RESET_BEFORE_COMBAT">Reiniciar antes de combate</translation>
-	<translation name="NON_PARTY_TRACKING">A los que no son miembros del partido</translation>
+	<translation name="NON_PARTY_TRACKING">Incluir a los que no son miembros del partido</translation>
 	<translation name="SEARCHED_PLAYER">Jugador buscado</translation>
 	<translation name="LOCAL_PLAYER">Jugador local</translation>
 	<translation name="THANKS">Agradecimientos</translation>

--- a/src/StatisticsAnalysisTool/Languages/es-ES.xml
+++ b/src/StatisticsAnalysisTool/Languages/es-ES.xml
@@ -659,6 +659,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Costes de reparación los últimos 7 días</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Costes de reparación los últimos 30 días</translation>
 	<translation name="RESET_BEFORE_COMBAT">Reiniciar antes de combate</translation>
+	<translation name="NON_PARTY_TRACKING">Incluir a miembros no partidistas</translation>
 	<translation name="SEARCHED_PLAYER">Jugador buscado</translation>
 	<translation name="LOCAL_PLAYER">Jugador local</translation>
 	<translation name="THANKS">Agradecimientos</translation>

--- a/src/StatisticsAnalysisTool/Languages/fr-FR.xml
+++ b/src/StatisticsAnalysisTool/Languages/fr-FR.xml
@@ -632,6 +632,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Frais de réparation les 7 derniers jours</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Frais de réparation les 30 derniers jours</translation>
 	<translation name="RESET_BEFORE_COMBAT">Réinitialiser avant le combat</translation>
+	<translation name="NON_PARTY_TRACKING">Inclure des membres non partisans</translation>
 	<translation name="SEARCHED_PLAYER">Joueur recherché</translation>
 	<translation name="LOCAL_PLAYER">Joueur local</translation>
 	<translation name="THANKS">Merci</translation>

--- a/src/StatisticsAnalysisTool/Languages/ja-JP.xml
+++ b/src/StatisticsAnalysisTool/Languages/ja-JP.xml
@@ -666,6 +666,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">7日間の修理費</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">30日間の修理費</translation>
 	<translation name="RESET_BEFORE_COMBAT">戦闘前にリセット</translation>
+	<translation name="NON_PARTY_TRACKING">非党派メンバーを含む (ひとうはメンバーをふくむ)</translation>
 	<translation name="SEARCHED_PLAYER">検索されたプレイヤー</translation>
 	<translation name="LOCAL_PLAYER">ローカルプレイヤー</translation>
 	<translation name="THANKS">Thanks</translation>

--- a/src/StatisticsAnalysisTool/Languages/ko-KR.xml
+++ b/src/StatisticsAnalysisTool/Languages/ko-KR.xml
@@ -621,6 +621,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">7일간 수리비</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">30일간 수리비</translation>
 	<translation name="RESET_BEFORE_COMBAT">전투 전 초기화</translation>
+	<translation name="NON_PARTY_TRACKING">비당원 포함 (비당원 포함)</translation>
 	<translation name="SEARCHED_PLAYER">플레이어 찾기</translation>
 	<translation name="LOCAL_PLAYER">Local player</translation>
 	<translation name="THANKS">감사</translation>

--- a/src/StatisticsAnalysisTool/Languages/pl-PL.xml
+++ b/src/StatisticsAnalysisTool/Languages/pl-PL.xml
@@ -620,6 +620,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Koszty naprawy z ostatnich 7 dni</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Koszty naprawy z ostatnich 30 dni</translation>
 	<translation name="RESET_BEFORE_COMBAT">Zresetuj przed walka</translation>
+	<translation name="NON_PARTY_TRACKING">Włączać członków spoza partii</translation>
 	<translation name="SEARCHED_PLAYER">Sprawdzony gracz</translation>
 	<translation name="LOCAL_PLAYER">Twoja postać</translation>
 	<translation name="THANKS">Dziękuję</translation>

--- a/src/StatisticsAnalysisTool/Languages/pt-BR.xml
+++ b/src/StatisticsAnalysisTool/Languages/pt-BR.xml
@@ -620,6 +620,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Os custos de reembolso duram 7 dias</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Os custos de reembolso duram 30 dias</translation>
 	<translation name="RESET_BEFORE_COMBAT">Reiniciar antes do combate</translation>
+	<translation name="NON_PARTY_TRACKING">Incluir membros não partidários</translation>
 	<translation name="SEARCHED_PLAYER">Jogador pesquisado</translation>
 	<translation name="LOCAL_PLAYER">Jogador local</translation>
 	<translation name="THANKS">Agradecimentos</translation>

--- a/src/StatisticsAnalysisTool/Languages/ru-RU.xml
+++ b/src/StatisticsAnalysisTool/Languages/ru-RU.xml
@@ -620,6 +620,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">Потрачено на починку за 7 дней</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">Потрачено на починку за месяц</translation>
 	<translation name="RESET_BEFORE_COMBAT">Сбрасывать перед битвой</translation>
+	<translation name="NON_PARTY_TRACKING">Включить непартийных членов</translation>
 	<translation name="SEARCHED_PLAYER">Найденный игрок</translation>
 	<translation name="LOCAL_PLAYER">Ваш персонаж</translation>
 	<translation name="THANKS">Спасибо</translation>

--- a/src/StatisticsAnalysisTool/Languages/zh-CN.xml
+++ b/src/StatisticsAnalysisTool/Languages/zh-CN.xml
@@ -620,6 +620,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">一周内维修花费</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">一月内维修花费</translation>
 	<translation name="RESET_BEFORE_COMBAT">进入战斗前重置</translation>
+	<translation name="NON_PARTY_TRACKING">包括非党派成员</translation>
 	<translation name="SEARCHED_PLAYER">搜索玩家</translation>
 	<translation name="LOCAL_PLAYER">本地玩家</translation>
 	<translation name="THANKS">鸣谢</translation>

--- a/src/StatisticsAnalysisTool/Languages/zh-TW.xml
+++ b/src/StatisticsAnalysisTool/Languages/zh-TW.xml
@@ -656,6 +656,7 @@
 	<translation name="REPAIR_COSTS_LAST_7_DAYS">7 日內修裝花費</translation>
 	<translation name="REPAIR_COSTS_LAST_30_DAYS">30 日內修裝花費</translation>
 	<translation name="RESET_BEFORE_COMBAT">進入戰鬥前重置</translation>
+	<translation name="NON_PARTY_TRACKING">包括非黨派成員</translation>
 	<translation name="SEARCHED_PLAYER">搜尋玩家</translation>
 	<translation name="LOCAL_PLAYER">本地玩家</translation>
 	<translation name="THANKS">鳴謝</translation>

--- a/src/StatisticsAnalysisTool/Models/TranslationModel/MainWindowTranslation.cs
+++ b/src/StatisticsAnalysisTool/Models/TranslationModel/MainWindowTranslation.cs
@@ -20,6 +20,7 @@ public class MainWindowTranslation
     public static string MakeSureYouHaveInstalledNpcap => LanguageController.Translation("MAKE_SURE_YOU_HAVE_INSTALLED_NPCAP");
     public static string MapChangeReset => LanguageController.Translation("MAP_CHANGE_RESET");
     public static string ResetBeforeCombat => LanguageController.Translation("RESET_BEFORE_COMBAT");
+    public static string NonPartyTracking => LanguageController.Translation("NON_PARTY_TRACKING");
     public static string SnapshotAfterMapChange => LanguageController.Translation("SNAPSHOT_AFTER_MAP_CHANGE");
     public static string TotalFame => LanguageController.Translation("TOTAL_FAME");
     public static string TotalSilver => LanguageController.Translation("TOTAL_SILVER");

--- a/src/StatisticsAnalysisTool/Network/Manager/CombatController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/CombatController.cs
@@ -52,8 +52,9 @@ public class CombatController
 
         var gameObject = _trackingController?.EntityController?.GetEntity(causerId);
         var gameObjectValue = gameObject?.Value;
+        var shouldBeTracked = _trackingController.EntityController.IsEntityInParty(gameObject.Value.Key) || SettingsController.CurrentSettings.IsDamageMeterNonPartyTrackingActive;
 
-        if (gameObject?.Value is not { ObjectType: GameObjectType.Player } || !_trackingController.EntityController.IsEntityInParty(gameObject.Value.Key))
+        if (gameObject?.Value is not { ObjectType: GameObjectType.Player } || !shouldBeTracked)
         {
             return Task.CompletedTask;
         }
@@ -89,7 +90,8 @@ public class CombatController
 
         gameObjectValue.CombatStart ??= DateTime.UtcNow;
 
-        OnDamageUpdate?.Invoke(_mainWindowViewModel?.DamageMeterBindings?.DamageMeter, _trackingController.EntityController.GetAllEntitiesWithDamageOrHealAndInParty());
+        var entities = _trackingController.EntityController.GetAllEntitiesWithDamageOrHeal(!SettingsController.CurrentSettings.IsDamageMeterNonPartyTrackingActive);
+        OnDamageUpdate?.Invoke(_mainWindowViewModel?.DamageMeterBindings?.DamageMeter, entities);
         return Task.CompletedTask;
     }
 

--- a/src/StatisticsAnalysisTool/Network/Manager/EntityController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/EntityController.cs
@@ -141,11 +141,11 @@ public class EntityController
         return new List<KeyValuePair<Guid, PlayerGameObject>>(onlyInParty ? _knownEntities.ToArray().Where(x => IsEntityInParty(x.Value.Name)) : _knownEntities.ToArray());
     }
 
-    public List<KeyValuePair<Guid, PlayerGameObject>> GetAllEntitiesWithDamageOrHealAndInParty()
+    public List<KeyValuePair<Guid, PlayerGameObject>> GetAllEntitiesWithDamageOrHeal(bool onlyInParty = true)
     {
         return new List<KeyValuePair<Guid, PlayerGameObject>>(_knownEntities
             .ToArray()
-            .Where(x => (x.Value.Damage > 0 || x.Value.Heal > 0 || x.Value.Overhealed > 0) && IsEntityInParty(x.Key)));
+            .Where(x => (x.Value.Damage > 0 || x.Value.Heal > 0 || x.Value.Overhealed > 0) && (!onlyInParty || IsEntityInParty(x.Key))));
     }
 
     public bool ExistEntity(Guid guid)

--- a/src/StatisticsAnalysisTool/UserControls/DamageMeterControl.xaml
+++ b/src/StatisticsAnalysisTool/UserControls/DamageMeterControl.xaml
@@ -74,6 +74,9 @@
                                     <CheckBox IsChecked="{Binding DamageMeterBindings.IsDamageMeterResetBeforeCombatActive}" 
                                           Content="{Binding Translation.ResetBeforeCombat, FallbackValue=RESET__BEFORE__COMBAT}" 
                                           HorizontalContentAlignment="Left" Margin="5,2,10,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="auto"/>
+                                    <CheckBox IsChecked="{Binding DamageMeterBindings.IsDamageMeterNonPartyTrackingActive}" 
+                                          Content="{Binding Translation.NonPartyTracking, FallbackValue=NON__PARTY__TRACKING}" 
+                                          HorizontalContentAlignment="Left" Margin="5,2,10,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="auto"/>
                                     <CheckBox IsChecked="{Binding DamageMeterBindings.IsSnapshotAfterMapChangeActive}" 
                                           Content="{Binding Translation.SnapshotAfterMapChange, FallbackValue=SNAPSHOT__AFTER__MAP__CHANGE}" 
                                           HorizontalContentAlignment="Left" Margin="5,2,10,0" VerticalAlignment="Top" HorizontalAlignment="Left" Width="auto"/>


### PR DESCRIPTION
## Checklist
- [x] This is not a **[duplicate](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] All new and existing tests pass.

## Changes
Added new setting "Include non-party members" to damage meters
Added translations for setting (from gpt)

### New functionality
Ability to toggle on or off tracking of outside party members

### Changed functionality
Modified CombatController to respect new setting
Modified EntityController "GetAllEntitiesWithDamageOrHealAndInParty" function to allow for both in party and non party retrieve

### Removed functionality
N/A

## Additional info
Translations were done using GPT, I only know English so not sure how good the translations are.

I've been using this version for a few days now, seems to work fine. Specifically wanted it for tracking enemy damage + healing in hellgates + arena