### PR TITLE
Load player kills asynchronously to start tracking faster

### DIFF
--- a/src/StatisticsAnalysisTool/Cluster/ClusterController.cs
+++ b/src/StatisticsAnalysisTool/Cluster/ClusterController.cs
@@ -70,7 +70,6 @@ public sealed class ClusterController
         _trackingController.TradeController.ResetCraftingBuildingInfo();
         _mainWindowViewModel.DamageMeterBindings.GetSnapshot(_mainWindowViewModel.DamageMeterBindings.IsSnapshotAfterMapChangeActive);
         _trackingController.CombatController.ResetDamageMeterByClusterChange();
-        _trackingController.StatisticController.SetKillsDeathsValues();
         _trackingController.VaultController.ResetDiscoveredItems();
         _trackingController.VaultController.ResetInternalVaultContainer();
         _trackingController.VaultController.ResetCurrentInternalVault();

--- a/src/StatisticsAnalysisTool/Localization/localization.json
+++ b/src/StatisticsAnalysisTool/Localization/localization.json
@@ -36546,6 +36546,47 @@
       ]
     },
     {
+      "tuid": "KILLS_DEATHS_LOADING",
+      "tuv": [
+        {
+          "lang": "de-DE",
+          "seg": "Tötungen / Tode (Lädt)"
+        },
+        {
+          "lang": "en-US",
+          "seg": "Kills / Deaths (Loading)"
+        },
+        {
+          "lang": "fr-FR",
+          "seg": "Tués / Morts (Chargement)"
+        },
+        {
+          "lang": "ja-JP",
+          "seg": "キル数 / 死亡数 (読み込み中)"
+        },
+        {
+          "lang": "ko-KR",
+          "seg": "킬 / 사망 (로딩 중)"
+        },
+        {
+          "lang": "pl-PL",
+          "seg": "Zabicia / Śmierci (Ładowanie)"
+        },
+        {
+          "lang": "pt-BR",
+          "seg": "Kills / Deaths (Loading)"
+        },
+        {
+          "lang": "ru-RU",
+          "seg": "Убийства / Смерти (Загрузка)"
+        },
+        {
+          "lang": "zh-CN",
+          "seg": "击杀 / 死亡 (加载中)"
+        }
+      ]
+    },
+    {
       "tuid": "REPAIR_COSTS",
       "tuv": [
         {

--- a/src/StatisticsAnalysisTool/Models/BindingModel/DashboardBindings.cs
+++ b/src/StatisticsAnalysisTool/Models/BindingModel/DashboardBindings.cs
@@ -57,6 +57,7 @@ public class DashboardBindings : BaseViewModel
     private EFontAwesomeIcon _reSpecStatsToggleIcon;
     private Visibility _repairCostsStatsVisibility;
     private EFontAwesomeIcon _repairCostsStatsToggleIcon;
+    private string _translationKillsDeaths = TranslationKillsDeaths;
 
     public DashboardBindings()
     {
@@ -402,6 +403,16 @@ public class DashboardBindings : BaseViewModel
 
     #region Kill / Death stats
 
+    public string KillsDeathsText
+    {
+        get => _translationKillsDeaths;
+        set
+        {
+            _translationKillsDeaths = value;
+            OnPropertyChanged();
+        }
+    }
+
     public int SoloKillsToday
     {
         get => _soloKillsToday;
@@ -627,6 +638,7 @@ public class DashboardBindings : BaseViewModel
     public static string TranslationRepairCostsLast7Days => LocalizationController.Translation("REPAIR_COSTS_LAST_7_DAYS");
     public static string TranslationRepairCostsLast30Days => LocalizationController.Translation("REPAIR_COSTS_LAST_30_DAYS");
     public static string TranslationKillsDeaths => LocalizationController.Translation("KILLS_DEATHS");
+    public static string TranslationKillsDeathsLoading => LocalizationController.Translation("KILLS_DEATHS_LOADING");
     public static string TranslationLootedChests => LocalizationController.Translation("LOOTED_CHESTS");
     public static string TranslationRepairCosts => LocalizationController.Translation("REPAIR_COSTS");
 }

--- a/src/StatisticsAnalysisTool/Models/NetworkModel/LocalUserData.cs
+++ b/src/StatisticsAnalysisTool/Models/NetworkModel/LocalUserData.cs
@@ -69,10 +69,8 @@ public class LocalUserData
     public double AverageItemPowerWhenDying =>
         PlayerKillsDeaths?.Where(x => x.ObjectType == GameInfoPlayerKillsDeathsType.Death && x.Victim?.Name == Username).Select(x => x.Victim?.AverageItemPower).Sum() / PlayerKillsDeaths?.ToArray().Count(x => x.ObjectType == GameInfoPlayerKillsDeathsType.Death) ?? 0;
 
-    public async Task SetValuesAsync(LocalUserData localUserData)
+    public void SetValues(LocalUserData localUserData)
     {
-        await GetApiData(Username, localUserData.Username);
-
         UserObjectId = localUserData.UserObjectId;
         Guid = localUserData.Guid;
         InteractGuid = localUserData.InteractGuid;
@@ -89,12 +87,12 @@ public class LocalUserData
         IsReSpecActive = localUserData.IsReSpecActive;
     }
 
-    private async Task GetApiData(string currentUsername, string newUsername)
+    public async Task GetApiData(string username)
     {
-        if (currentUsername != newUsername || LastUpdate < DateTime.UtcNow.AddMinutes(-5))
+        if (LastUpdate == null || LastUpdate < DateTime.UtcNow.AddMinutes(-5))
         {
-            var info = await ApiController.GetGameInfoSearchFromJsonAsync(newUsername);
-            WebApiUserId = GetWebApiUserId(info, newUsername)?.Id;
+            var info = await ApiController.GetGameInfoSearchFromJsonAsync(username);
+            WebApiUserId = GetWebApiUserId(info, username)?.Id;
 
             await AddPlayerKillsDeathsToListAsync(await ApiController.GetGameInfoPlayerKillsDeathsFromJsonAsync(WebApiUserId, GameInfoPlayersType.Deaths), GameInfoPlayerKillsDeathsType.Death);
             await AddPlayerKillsDeathsToListAsync(await ApiController.GetGameInfoPlayerTopKillsFromJsonAsync(WebApiUserId, UnitOfTime.Month), GameInfoPlayerKillsDeathsType.Kill);

--- a/src/StatisticsAnalysisTool/Network/Handler/JoinResponseHandler.cs
+++ b/src/StatisticsAnalysisTool/Network/Handler/JoinResponseHandler.cs
@@ -9,6 +9,7 @@ using StatisticsAnalysisTool.ViewModels;
 using System;
 using System.Threading.Tasks;
 using System.Windows;
+using StatisticsAnalysisTool.Models.BindingModel;
 
 namespace StatisticsAnalysisTool.Network.Handler;
 
@@ -25,7 +26,8 @@ public class JoinResponseHandler : ResponsePacketHandler<JoinResponse>
 
     protected override async Task OnActionAsync(JoinResponse value)
     {
-        await SetLocalUserData(value);
+        SetLocalUserData(value);
+        _ = SetApiUserData(value);
 
         _trackingController.ClusterController.SetJoinClusterInformation(value.MapIndex, value.MainMapIndex, value.MapGuid);
 
@@ -57,9 +59,9 @@ public class JoinResponseHandler : ResponsePacketHandler<JoinResponse>
         await _mainWindowViewModel?.PlayerInformationBindings?.LoadLocalPlayerDataAsync(value.Username)!;
     }
 
-    private async Task SetLocalUserData(JoinResponse value)
+    private void SetLocalUserData(JoinResponse value)
     {
-        await _trackingController.EntityController.LocalUserData.SetValuesAsync(new LocalUserData
+        _trackingController.EntityController.LocalUserData.SetValues(new LocalUserData
         {
             UserObjectId = value.UserObjectId,
             Guid = value.UserGuid,
@@ -76,6 +78,14 @@ public class JoinResponseHandler : ResponsePacketHandler<JoinResponse>
             AllianceName = value.AllianceName,
             IsReSpecActive = value.IsReSpecActive
         });
+    }
+
+    private async Task SetApiUserData(JoinResponse value)
+    {
+        _mainWindowViewModel.DashboardBindings.KillsDeathsText = DashboardBindings.TranslationKillsDeathsLoading;
+        await _trackingController.EntityController.LocalUserData.GetApiData(value.Username);
+        _mainWindowViewModel.DashboardBindings.KillsDeathsText = DashboardBindings.TranslationKillsDeaths;
+        _trackingController.StatisticController.SetKillsDeathsValues();
     }
 
     private async Task AddEntityAsync(Entity entity)

--- a/src/StatisticsAnalysisTool/UserControls/DashboardControl.xaml
+++ b/src/StatisticsAnalysisTool/UserControls/DashboardControl.xaml
@@ -73,7 +73,7 @@
                 <StackPanel Orientation="Horizontal" Height="20" Background="{StaticResource SolidColorBrush.Background.3}" MouseLeftButtonDown="KillDeathToggle_OnMouseLeftButtonDown">
                     <fa5:ImageAwesome Icon="{Binding DashboardBindings.KillDeathStatsToggleIcon, FallbackValue='Solid_Minus'}" 
                                       Foreground="{StaticResource SolidColorBrush.Text.1}" Height="14" Width="14" Margin="10,0" VerticalAlignment="Center" />
-                    <TextBlock Text="{Binding DashboardBindings.TranslationKillsDeaths, FallbackValue='KILL_DEATHS'}" 
+                    <TextBlock Text="{Binding DashboardBindings.KillsDeathsText, FallbackValue='KILL_DEATHS'}" 
                                Foreground="{StaticResource SolidColorBrush.Accent.Blue.3}" FontSize="16" VerticalAlignment="Center" />
                 </StackPanel>
                 <ContentControl Visibility="{Binding DashboardBindings.KillDeathStatsVisibility}" Margin="3" 


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [X] This is not a **[duplicate](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/pulls)** of an existing merge request.
- [X] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [X] All new and existing tests pass.

## Changes

Fixes #550 

### New functionality

None

### Changed functionality

Player kills are loaded from the API synchronously so that tracking can start immediately after switching zones.

### Removed functionality

None

## Additional info

More info in the linked issue














