### PR TITLE
feat: add lifetime stats panel to dashboard

### DIFF
--- a/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
+++ b/src/StatisticsAnalysisTool/Common/UserSettings/SettingsObject.cs
@@ -102,6 +102,7 @@ public class SettingsObject
     public bool IsLootedChestsStatsVisible { get; set; } = true;
     public bool IsReSpecStatsVisible { get; set; } = true;
     public bool IsRepairCostsStatsVisible { get; set; } = true;
+    public bool IsLifetimeStatsVisible { get; set; } = true;
     public string ProxyUrlWithPort { get; set; }
     public string DebugConsoleFilter { get; set; }
     public bool IsOpenDebugConsoleWhenStartingTheToolChecked { get; set; } = false;

--- a/src/StatisticsAnalysisTool/Enumerations/ValueType.cs
+++ b/src/StatisticsAnalysisTool/Enumerations/ValueType.cs
@@ -11,5 +11,7 @@ public enum ValueType
     Favor,
     RepairCosts,
     PaidSilverForReSpec,
-    BrecilianStanding
+    BrecilianStanding,
+    ActiveTime = 100,
+    GatheringValue = 101
 }

--- a/src/StatisticsAnalysisTool/Gathering/GatheringController.cs
+++ b/src/StatisticsAnalysisTool/Gathering/GatheringController.cs
@@ -5,7 +5,9 @@ using StatisticsAnalysisTool.Common.UserSettings;
 using StatisticsAnalysisTool.EstimatedMarketValue;
 using StatisticsAnalysisTool.Models;
 using StatisticsAnalysisTool.Models.NetworkModel;
+using StatisticsAnalysisTool.Enumerations;
 using StatisticsAnalysisTool.Network.Manager;
+using ValueType = StatisticsAnalysisTool.Enumerations.ValueType;
 using StatisticsAnalysisTool.Properties;
 using StatisticsAnalysisTool.ViewModels;
 using System;
@@ -56,17 +58,22 @@ public class GatheringController
             existingGatheredObject.GainedBonusAmount += harvestFinishedObject.CollectorBonusAmount;
             existingGatheredObject.GainedPremiumBonusAmount += harvestFinishedObject.PremiumBonusAmount;
             existingGatheredObject.MiningProcesses++;
+            var amountDelta = harvestFinishedObject.StandardAmount + harvestFinishedObject.CollectorBonusAmount + harvestFinishedObject.PremiumBonusAmount;
+            var valueDelta = FixPoint.FromFloatingPointValue(amountDelta * existingGatheredObject.EstimatedMarketValue.IntegerValue).DoubleValue;
+            _trackingController.StatisticController?.AddValue(ValueType.GatheringValue, valueDelta);
+            _trackingController.LiveStatsTracker?.Add(ValueType.GatheringValue, valueDelta);
         }
         else
         {
             var item = ItemController.GetItemByIndex(harvestFinishedObject.ItemId);
+            var emv = EstimatedMarketValueController.CalculateNearestToAverage(item.EstimatedMarketValues).MarketValue;
             var gathered = new Gathered()
             {
                 TimestampUtc = DateTime.UtcNow.Ticks,
                 UniqueName = item.UniqueName,
                 UserObjectId = harvestFinishedObject.UserObjectId,
                 ObjectId = harvestFinishedObject.ObjectId,
-                EstimatedMarketValue = EstimatedMarketValueController.CalculateNearestToAverage(item.EstimatedMarketValues).MarketValue,
+                EstimatedMarketValue = emv,
                 GainedStandardAmount = harvestFinishedObject.StandardAmount,
                 GainedBonusAmount = harvestFinishedObject.CollectorBonusAmount,
                 GainedPremiumBonusAmount = harvestFinishedObject.PremiumBonusAmount,
@@ -75,6 +82,13 @@ public class GatheringController
                 InstanceName = ClusterController.CurrentCluster.InstanceName,
                 MiningProcesses = 1
             };
+
+            // Emit value for the first harvest of this node so it is counted
+            // in the same way the Gathering tab's TotalMarketValue sum does.
+            var totalAmount = harvestFinishedObject.StandardAmount + harvestFinishedObject.CollectorBonusAmount + harvestFinishedObject.PremiumBonusAmount;
+            var initialValue = FixPoint.FromFloatingPointValue(totalAmount * emv.IntegerValue).DoubleValue;
+            _trackingController.StatisticController?.AddValue(ValueType.GatheringValue, initialValue);
+            _trackingController.LiveStatsTracker?.Add(ValueType.GatheringValue, initialValue);
 
             AddGatheredToBindingCollection(gathered);
             await RemoveEntriesByAutoDeleteDateAsync();
@@ -226,6 +240,10 @@ public class GatheringController
             };
 
             AddGatheredToBindingCollection(gathered);
+
+            var fishedValue = gathered.TotalMarketValue.DoubleValue;
+            _trackingController.StatisticController?.AddValue(ValueType.GatheringValue, fishedValue);
+            _trackingController.LiveStatsTracker?.Add(ValueType.GatheringValue, fishedValue);
             itemCount++;
         }
 

--- a/src/StatisticsAnalysisTool/Localization/localization.json
+++ b/src/StatisticsAnalysisTool/Localization/localization.json
@@ -24877,6 +24877,55 @@
       ]
     },
     {
+      "tuid": "SESSION",
+      "tuv": [
+        {
+          "lang": "de-DE",
+          "seg": "Sitzung"
+        },
+        {
+          "lang": "en-US",
+          "seg": "Session"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Sesión"
+        },
+        {
+          "lang": "fr-FR",
+          "seg": "Session"
+        },
+        {
+          "lang": "ja-JP",
+          "seg": "セッション"
+        },
+        {
+          "lang": "ko-KR",
+          "seg": "세션"
+        },
+        {
+          "lang": "pl-PL",
+          "seg": "Sesja"
+        },
+        {
+          "lang": "pt-BR",
+          "seg": "Sessão"
+        },
+        {
+          "lang": "ru-RU",
+          "seg": "Сессия"
+        },
+        {
+          "lang": "tr-TR",
+          "seg": "Oturum"
+        },
+        {
+          "lang": "zh-CN",
+          "seg": "本次会话"
+        }
+      ]
+    },
+    {
       "tuid": "TODAY",
       "tuv": [
         {
@@ -36551,6 +36600,51 @@
         {
           "lang": "zh-CN",
           "seg": "击杀 / 死亡 (加载中)"
+        }
+      ]
+    },
+    {
+      "tuid": "LIFETIME_STATS",
+      "tuv": [
+        {
+          "lang": "de-DE",
+          "seg": "Lebenszeitleistung"
+        },
+        {
+          "lang": "en-US",
+          "seg": "Lifetime Stats"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Estadísticas de por vida"
+        },
+        {
+          "lang": "fr-FR",
+          "seg": "Statistiques à vie"
+        },
+        {
+          "lang": "ko-KR",
+          "seg": "평생 통계"
+        },
+        {
+          "lang": "pl-PL",
+          "seg": "Statystyki całego okresu"
+        },
+        {
+          "lang": "pt-BR",
+          "seg": "Estatísticas vitalícias"
+        },
+        {
+          "lang": "ru-RU",
+          "seg": "Статистика за всё время"
+        },
+        {
+          "lang": "tr-TR",
+          "seg": "Tüm Zamanlar"
+        },
+        {
+          "lang": "zh-CN",
+          "seg": "终生统计"
         }
       ]
     },

--- a/src/StatisticsAnalysisTool/Models/BindingModel/DashboardBindings.cs
+++ b/src/StatisticsAnalysisTool/Models/BindingModel/DashboardBindings.cs
@@ -24,6 +24,8 @@ public class DashboardBindings : BaseViewModel
     private double _totalGainedMightInSession;
     private double _totalGainedFavorInSession;
     private double _totalSilverCostForReSpecInSession;
+    private double _totalGatheredValueInSession;
+    private double _gatheringValuePerHour;
     private double _highestValue;
     private double _fameInPercent;
     private double _silverInPercent;
@@ -57,6 +59,9 @@ public class DashboardBindings : BaseViewModel
     private EFontAwesomeIcon _reSpecStatsToggleIcon;
     private Visibility _repairCostsStatsVisibility;
     private EFontAwesomeIcon _repairCostsStatsToggleIcon;
+    private LifetimeStats _lifetimeStats = new();
+    private Visibility _lifetimeStatsVisibility;
+    private EFontAwesomeIcon _lifetimeStatsToggleIcon;
     private string _translationKillsDeaths = TranslationKillsDeaths;
 
     public DashboardBindings()
@@ -74,6 +79,9 @@ public class DashboardBindings : BaseViewModel
 
         RepairCostsStatsVisibility = SettingsController.CurrentSettings.IsRepairCostsStatsVisible ? Visibility.Visible : Visibility.Collapsed;
         RepairCostsStatsToggleIcon = SettingsController.CurrentSettings.IsRepairCostsStatsVisible ? EFontAwesomeIcon.Solid_Minus : EFontAwesomeIcon.Solid_Plus;
+
+        LifetimeStatsVisibility = SettingsController.CurrentSettings.IsLifetimeStatsVisible ? Visibility.Visible : Visibility.Collapsed;
+        LifetimeStatsToggleIcon = SettingsController.CurrentSettings.IsLifetimeStatsVisible ? EFontAwesomeIcon.Solid_Minus : EFontAwesomeIcon.Solid_Plus;
     }
 
     #region Toggle
@@ -162,6 +170,27 @@ public class DashboardBindings : BaseViewModel
         }
     }
 
+    public Visibility LifetimeStatsVisibility
+    {
+        get => _lifetimeStatsVisibility;
+        set
+        {
+            _lifetimeStatsVisibility = value;
+            SettingsController.CurrentSettings.IsLifetimeStatsVisible = value == Visibility.Visible;
+            OnPropertyChanged();
+        }
+    }
+
+    public EFontAwesomeIcon LifetimeStatsToggleIcon
+    {
+        get => _lifetimeStatsToggleIcon;
+        set
+        {
+            _lifetimeStatsToggleIcon = value;
+            OnPropertyChanged();
+        }
+    }
+
     #endregion
 
     #region Fame / Respec / Silver / Might / Faction
@@ -195,6 +224,8 @@ public class DashboardBindings : BaseViewModel
         TotalGainedReSpecPointsInSession = 0;
         TotalGainedMightInSession = 0;
         TotalGainedFavorInSession = 0;
+        TotalGatheredValueInSession = 0;
+        GatheringValuePerHour = 0;
     }
 
     #region Per hour values
@@ -255,6 +286,16 @@ public class DashboardBindings : BaseViewModel
         set
         {
             _favorPerHour = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public double GatheringValuePerHour
+    {
+        get => _gatheringValuePerHour;
+        set
+        {
+            _gatheringValuePerHour = value;
             OnPropertyChanged();
         }
     }
@@ -383,6 +424,16 @@ public class DashboardBindings : BaseViewModel
             _totalGainedFavorInSession = value;
             HighestValue = GetHighestValue();
             FavorInPercent = _totalGainedFavorInSession / HighestValue * 100;
+            OnPropertyChanged();
+        }
+    }
+
+    public double TotalGatheredValueInSession
+    {
+        get => _totalGatheredValueInSession;
+        set
+        {
+            _totalGatheredValueInSession = value;
             OnPropertyChanged();
         }
     }
@@ -559,6 +610,20 @@ public class DashboardBindings : BaseViewModel
 
     #endregion
 
+    #region Lifetime stats
+
+    public LifetimeStats LifetimeStats
+    {
+        get => _lifetimeStats;
+        set
+        {
+            _lifetimeStats = value;
+            OnPropertyChanged();
+        }
+    }
+
+    #endregion
+
     #region Repair costs
 
     public long RepairCostsToday
@@ -641,4 +706,5 @@ public class DashboardBindings : BaseViewModel
     public static string TranslationKillsDeathsLoading => LocalizationController.Translation("KILLS_DEATHS_LOADING");
     public static string TranslationLootedChests => LocalizationController.Translation("LOOTED_CHESTS");
     public static string TranslationRepairCosts => LocalizationController.Translation("REPAIR_COSTS");
+    public static string TranslationLifetimeStats => LocalizationController.Translation("LIFETIME_STATS");
 }

--- a/src/StatisticsAnalysisTool/Models/LifetimeStats.cs
+++ b/src/StatisticsAnalysisTool/Models/LifetimeStats.cs
@@ -16,7 +16,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecToday;
     private double _mightToday;
     private double _favorToday;
-    private double _factionFameToday;
+    private double _factionPointsToday;
     private double _gatheringValueToday;
 
     #endregion
@@ -28,7 +28,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecThisWeek;
     private double _mightThisWeek;
     private double _favorThisWeek;
-    private double _factionFameThisWeek;
+    private double _factionPointsThisWeek;
     private double _gatheringValueThisWeek;
 
     #endregion
@@ -40,7 +40,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecLastWeek;
     private double _mightLastWeek;
     private double _favorLastWeek;
-    private double _factionFameLastWeek;
+    private double _factionPointsLastWeek;
     private double _gatheringValueLastWeek;
 
     #endregion
@@ -52,7 +52,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecThisMonth;
     private double _mightThisMonth;
     private double _favorThisMonth;
-    private double _factionFameThisMonth;
+    private double _factionPointsThisMonth;
     private double _gatheringValueThisMonth;
 
     #endregion
@@ -64,7 +64,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecLastMonth;
     private double _mightLastMonth;
     private double _favorLastMonth;
-    private double _factionFameLastMonth;
+    private double _factionPointsLastMonth;
     private double _gatheringValueLastMonth;
 
     #endregion
@@ -76,7 +76,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecThisYear;
     private double _mightThisYear;
     private double _favorThisYear;
-    private double _factionFameThisYear;
+    private double _factionPointsThisYear;
     private double _gatheringValueThisYear;
 
     #endregion
@@ -88,7 +88,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecTotal;
     private double _mightTotal;
     private double _favorTotal;
-    private double _factionFameTotal;
+    private double _factionPointsTotal;
     private double _gatheringValueTotal;
 
     #endregion
@@ -125,10 +125,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorToday = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameToday
+    public double FactionPointsToday
     {
-        get => _factionFameToday;
-        set { _factionFameToday = value; OnPropertyChanged(); }
+        get => _factionPointsToday;
+        set { _factionPointsToday = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueToday
@@ -171,10 +171,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorThisWeek = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameThisWeek
+    public double FactionPointsThisWeek
     {
-        get => _factionFameThisWeek;
-        set { _factionFameThisWeek = value; OnPropertyChanged(); }
+        get => _factionPointsThisWeek;
+        set { _factionPointsThisWeek = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueThisWeek
@@ -217,10 +217,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorLastWeek = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameLastWeek
+    public double FactionPointsLastWeek
     {
-        get => _factionFameLastWeek;
-        set { _factionFameLastWeek = value; OnPropertyChanged(); }
+        get => _factionPointsLastWeek;
+        set { _factionPointsLastWeek = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueLastWeek
@@ -263,10 +263,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorThisMonth = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameThisMonth
+    public double FactionPointsThisMonth
     {
-        get => _factionFameThisMonth;
-        set { _factionFameThisMonth = value; OnPropertyChanged(); }
+        get => _factionPointsThisMonth;
+        set { _factionPointsThisMonth = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueThisMonth
@@ -309,10 +309,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorLastMonth = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameLastMonth
+    public double FactionPointsLastMonth
     {
-        get => _factionFameLastMonth;
-        set { _factionFameLastMonth = value; OnPropertyChanged(); }
+        get => _factionPointsLastMonth;
+        set { _factionPointsLastMonth = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueLastMonth
@@ -355,10 +355,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorThisYear = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameThisYear
+    public double FactionPointsThisYear
     {
-        get => _factionFameThisYear;
-        set { _factionFameThisYear = value; OnPropertyChanged(); }
+        get => _factionPointsThisYear;
+        set { _factionPointsThisYear = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueThisYear
@@ -401,10 +401,10 @@ public class LifetimeStats : BaseViewModel
         set { _favorTotal = value; OnPropertyChanged(); }
     }
 
-    public double FactionFameTotal
+    public double FactionPointsTotal
     {
-        get => _factionFameTotal;
-        set { _factionFameTotal = value; OnPropertyChanged(); }
+        get => _factionPointsTotal;
+        set { _factionPointsTotal = value; OnPropertyChanged(); }
     }
 
     public double GatheringValueTotal
@@ -445,7 +445,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecTodayPerHour;
     private double _mightTodayPerHour;
     private double _favorTodayPerHour;
-    private double _factionFameTodayPerHour;
+    private double _factionPointsTodayPerHour;
     private double _gatheringValueTodayPerHour;
 
     #endregion
@@ -457,7 +457,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecThisWeekPerHour;
     private double _mightThisWeekPerHour;
     private double _favorThisWeekPerHour;
-    private double _factionFameThisWeekPerHour;
+    private double _factionPointsThisWeekPerHour;
     private double _gatheringValueThisWeekPerHour;
 
     #endregion
@@ -469,7 +469,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecLastWeekPerHour;
     private double _mightLastWeekPerHour;
     private double _favorLastWeekPerHour;
-    private double _factionFameLastWeekPerHour;
+    private double _factionPointsLastWeekPerHour;
     private double _gatheringValueLastWeekPerHour;
 
     #endregion
@@ -481,7 +481,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecThisMonthPerHour;
     private double _mightThisMonthPerHour;
     private double _favorThisMonthPerHour;
-    private double _factionFameThisMonthPerHour;
+    private double _factionPointsThisMonthPerHour;
     private double _gatheringValueThisMonthPerHour;
 
     #endregion
@@ -493,7 +493,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecLastMonthPerHour;
     private double _mightLastMonthPerHour;
     private double _favorLastMonthPerHour;
-    private double _factionFameLastMonthPerHour;
+    private double _factionPointsLastMonthPerHour;
     private double _gatheringValueLastMonthPerHour;
 
     #endregion
@@ -505,7 +505,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecThisYearPerHour;
     private double _mightThisYearPerHour;
     private double _favorThisYearPerHour;
-    private double _factionFameThisYearPerHour;
+    private double _factionPointsThisYearPerHour;
     private double _gatheringValueThisYearPerHour;
 
     #endregion
@@ -517,7 +517,7 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecTotalPerHour;
     private double _mightTotalPerHour;
     private double _favorTotalPerHour;
-    private double _factionFameTotalPerHour;
+    private double _factionPointsTotalPerHour;
     private double _gatheringValueTotalPerHour;
 
     #endregion
@@ -529,13 +529,13 @@ public class LifetimeStats : BaseViewModel
     private double _reSpecSession;
     private double _mightSession;
     private double _favorSession;
-    private double _factionFameSession;
+    private double _factionPointsSession;
     private double _fameSessionPerHour;
     private double _silverSessionPerHour;
     private double _reSpecSessionPerHour;
     private double _mightSessionPerHour;
     private double _favorSessionPerHour;
-    private double _factionFameSessionPerHour;
+    private double _factionPointsSessionPerHour;
     private double _gatheringValueSession;
     private double _gatheringValueSessionPerHour;
     private CityFaction _cityFaction;
@@ -557,7 +557,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecTodayPerHour { get => _reSpecTodayPerHour; set { _reSpecTodayPerHour = value; OnPropertyChanged(); } }
     public double MightTodayPerHour { get => _mightTodayPerHour; set { _mightTodayPerHour = value; OnPropertyChanged(); } }
     public double FavorTodayPerHour { get => _favorTodayPerHour; set { _favorTodayPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameTodayPerHour { get => _factionFameTodayPerHour; set { _factionFameTodayPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsTodayPerHour { get => _factionPointsTodayPerHour; set { _factionPointsTodayPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueTodayPerHour { get => _gatheringValueTodayPerHour; set { _gatheringValueTodayPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -569,7 +569,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecThisWeekPerHour { get => _reSpecThisWeekPerHour; set { _reSpecThisWeekPerHour = value; OnPropertyChanged(); } }
     public double MightThisWeekPerHour { get => _mightThisWeekPerHour; set { _mightThisWeekPerHour = value; OnPropertyChanged(); } }
     public double FavorThisWeekPerHour { get => _favorThisWeekPerHour; set { _favorThisWeekPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameThisWeekPerHour { get => _factionFameThisWeekPerHour; set { _factionFameThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsThisWeekPerHour { get => _factionPointsThisWeekPerHour; set { _factionPointsThisWeekPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueThisWeekPerHour { get => _gatheringValueThisWeekPerHour; set { _gatheringValueThisWeekPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -581,7 +581,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecLastWeekPerHour { get => _reSpecLastWeekPerHour; set { _reSpecLastWeekPerHour = value; OnPropertyChanged(); } }
     public double MightLastWeekPerHour { get => _mightLastWeekPerHour; set { _mightLastWeekPerHour = value; OnPropertyChanged(); } }
     public double FavorLastWeekPerHour { get => _favorLastWeekPerHour; set { _favorLastWeekPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameLastWeekPerHour { get => _factionFameLastWeekPerHour; set { _factionFameLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsLastWeekPerHour { get => _factionPointsLastWeekPerHour; set { _factionPointsLastWeekPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueLastWeekPerHour { get => _gatheringValueLastWeekPerHour; set { _gatheringValueLastWeekPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -593,7 +593,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecThisMonthPerHour { get => _reSpecThisMonthPerHour; set { _reSpecThisMonthPerHour = value; OnPropertyChanged(); } }
     public double MightThisMonthPerHour { get => _mightThisMonthPerHour; set { _mightThisMonthPerHour = value; OnPropertyChanged(); } }
     public double FavorThisMonthPerHour { get => _favorThisMonthPerHour; set { _favorThisMonthPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameThisMonthPerHour { get => _factionFameThisMonthPerHour; set { _factionFameThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsThisMonthPerHour { get => _factionPointsThisMonthPerHour; set { _factionPointsThisMonthPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueThisMonthPerHour { get => _gatheringValueThisMonthPerHour; set { _gatheringValueThisMonthPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -605,7 +605,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecLastMonthPerHour { get => _reSpecLastMonthPerHour; set { _reSpecLastMonthPerHour = value; OnPropertyChanged(); } }
     public double MightLastMonthPerHour { get => _mightLastMonthPerHour; set { _mightLastMonthPerHour = value; OnPropertyChanged(); } }
     public double FavorLastMonthPerHour { get => _favorLastMonthPerHour; set { _favorLastMonthPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameLastMonthPerHour { get => _factionFameLastMonthPerHour; set { _factionFameLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsLastMonthPerHour { get => _factionPointsLastMonthPerHour; set { _factionPointsLastMonthPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueLastMonthPerHour { get => _gatheringValueLastMonthPerHour; set { _gatheringValueLastMonthPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -617,7 +617,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecThisYearPerHour { get => _reSpecThisYearPerHour; set { _reSpecThisYearPerHour = value; OnPropertyChanged(); } }
     public double MightThisYearPerHour { get => _mightThisYearPerHour; set { _mightThisYearPerHour = value; OnPropertyChanged(); } }
     public double FavorThisYearPerHour { get => _favorThisYearPerHour; set { _favorThisYearPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameThisYearPerHour { get => _factionFameThisYearPerHour; set { _factionFameThisYearPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsThisYearPerHour { get => _factionPointsThisYearPerHour; set { _factionPointsThisYearPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueThisYearPerHour { get => _gatheringValueThisYearPerHour; set { _gatheringValueThisYearPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -629,7 +629,7 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecTotalPerHour { get => _reSpecTotalPerHour; set { _reSpecTotalPerHour = value; OnPropertyChanged(); } }
     public double MightTotalPerHour { get => _mightTotalPerHour; set { _mightTotalPerHour = value; OnPropertyChanged(); } }
     public double FavorTotalPerHour { get => _favorTotalPerHour; set { _favorTotalPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameTotalPerHour { get => _factionFameTotalPerHour; set { _factionFameTotalPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsTotalPerHour { get => _factionPointsTotalPerHour; set { _factionPointsTotalPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueTotalPerHour { get => _gatheringValueTotalPerHour; set { _gatheringValueTotalPerHour = value; OnPropertyChanged(); } }
 
     #endregion
@@ -641,13 +641,13 @@ public class LifetimeStats : BaseViewModel
     public double ReSpecSession { get => _reSpecSession; set { _reSpecSession = value; OnPropertyChanged(); } }
     public double MightSession { get => _mightSession; set { _mightSession = value; OnPropertyChanged(); } }
     public double FavorSession { get => _favorSession; set { _favorSession = value; OnPropertyChanged(); } }
-    public double FactionFameSession { get => _factionFameSession; set { _factionFameSession = value; OnPropertyChanged(); } }
+    public double FactionPointsSession { get => _factionPointsSession; set { _factionPointsSession = value; OnPropertyChanged(); } }
     public double FameSessionPerHour { get => _fameSessionPerHour; set { _fameSessionPerHour = value; OnPropertyChanged(); } }
     public double SilverSessionPerHour { get => _silverSessionPerHour; set { _silverSessionPerHour = value; OnPropertyChanged(); } }
     public double ReSpecSessionPerHour { get => _reSpecSessionPerHour; set { _reSpecSessionPerHour = value; OnPropertyChanged(); } }
     public double MightSessionPerHour { get => _mightSessionPerHour; set { _mightSessionPerHour = value; OnPropertyChanged(); } }
     public double FavorSessionPerHour { get => _favorSessionPerHour; set { _favorSessionPerHour = value; OnPropertyChanged(); } }
-    public double FactionFameSessionPerHour { get => _factionFameSessionPerHour; set { _factionFameSessionPerHour = value; OnPropertyChanged(); } }
+    public double FactionPointsSessionPerHour { get => _factionPointsSessionPerHour; set { _factionPointsSessionPerHour = value; OnPropertyChanged(); } }
     public double GatheringValueSession { get => _gatheringValueSession; set { _gatheringValueSession = value; OnPropertyChanged(); } }
     public double GatheringValueSessionPerHour { get => _gatheringValueSessionPerHour; set { _gatheringValueSessionPerHour = value; OnPropertyChanged(); } }
     public CityFaction CityFaction { get => _cityFaction; set { _cityFaction = value; OnPropertyChanged(); } }

--- a/src/StatisticsAnalysisTool/Models/LifetimeStats.cs
+++ b/src/StatisticsAnalysisTool/Models/LifetimeStats.cs
@@ -1,0 +1,667 @@
+using StatisticsAnalysisTool.Enumerations;
+using StatisticsAnalysisTool.Localization;
+using StatisticsAnalysisTool.ViewModels;
+
+namespace StatisticsAnalysisTool.Models;
+
+/// <summary>
+/// Persistent aggregated stats across configurable timeframes, derived from stored DailyValues.
+/// </summary>
+public class LifetimeStats : BaseViewModel
+{
+    #region Backing fields – Today
+
+    private double _fameToday;
+    private double _silverToday;
+    private double _reSpecToday;
+    private double _mightToday;
+    private double _favorToday;
+    private double _factionFameToday;
+    private double _gatheringValueToday;
+
+    #endregion
+
+    #region Backing fields – This Week
+
+    private double _fameThisWeek;
+    private double _silverThisWeek;
+    private double _reSpecThisWeek;
+    private double _mightThisWeek;
+    private double _favorThisWeek;
+    private double _factionFameThisWeek;
+    private double _gatheringValueThisWeek;
+
+    #endregion
+
+    #region Backing fields – Last Week
+
+    private double _fameLastWeek;
+    private double _silverLastWeek;
+    private double _reSpecLastWeek;
+    private double _mightLastWeek;
+    private double _favorLastWeek;
+    private double _factionFameLastWeek;
+    private double _gatheringValueLastWeek;
+
+    #endregion
+
+    #region Backing fields – This Month
+
+    private double _fameThisMonth;
+    private double _silverThisMonth;
+    private double _reSpecThisMonth;
+    private double _mightThisMonth;
+    private double _favorThisMonth;
+    private double _factionFameThisMonth;
+    private double _gatheringValueThisMonth;
+
+    #endregion
+
+    #region Backing fields – Last Month
+
+    private double _fameLastMonth;
+    private double _silverLastMonth;
+    private double _reSpecLastMonth;
+    private double _mightLastMonth;
+    private double _favorLastMonth;
+    private double _factionFameLastMonth;
+    private double _gatheringValueLastMonth;
+
+    #endregion
+
+    #region Backing fields – This Year
+
+    private double _fameThisYear;
+    private double _silverThisYear;
+    private double _reSpecThisYear;
+    private double _mightThisYear;
+    private double _favorThisYear;
+    private double _factionFameThisYear;
+    private double _gatheringValueThisYear;
+
+    #endregion
+
+    #region Backing fields – Total
+
+    private double _fameTotal;
+    private double _silverTotal;
+    private double _reSpecTotal;
+    private double _mightTotal;
+    private double _favorTotal;
+    private double _factionFameTotal;
+    private double _gatheringValueTotal;
+
+    #endregion
+
+    #region Today
+
+    public double FameToday
+    {
+        get => _fameToday;
+        set { _fameToday = value; OnPropertyChanged(); }
+    }
+
+    public double SilverToday
+    {
+        get => _silverToday;
+        set { _silverToday = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecToday
+    {
+        get => _reSpecToday;
+        set { _reSpecToday = value; OnPropertyChanged(); }
+    }
+
+    public double MightToday
+    {
+        get => _mightToday;
+        set { _mightToday = value; OnPropertyChanged(); }
+    }
+
+    public double FavorToday
+    {
+        get => _favorToday;
+        set { _favorToday = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameToday
+    {
+        get => _factionFameToday;
+        set { _factionFameToday = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueToday
+    {
+        get => _gatheringValueToday;
+        set { _gatheringValueToday = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region This Week
+
+    public double FameThisWeek
+    {
+        get => _fameThisWeek;
+        set { _fameThisWeek = value; OnPropertyChanged(); }
+    }
+
+    public double SilverThisWeek
+    {
+        get => _silverThisWeek;
+        set { _silverThisWeek = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecThisWeek
+    {
+        get => _reSpecThisWeek;
+        set { _reSpecThisWeek = value; OnPropertyChanged(); }
+    }
+
+    public double MightThisWeek
+    {
+        get => _mightThisWeek;
+        set { _mightThisWeek = value; OnPropertyChanged(); }
+    }
+
+    public double FavorThisWeek
+    {
+        get => _favorThisWeek;
+        set { _favorThisWeek = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameThisWeek
+    {
+        get => _factionFameThisWeek;
+        set { _factionFameThisWeek = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueThisWeek
+    {
+        get => _gatheringValueThisWeek;
+        set { _gatheringValueThisWeek = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region Last Week
+
+    public double FameLastWeek
+    {
+        get => _fameLastWeek;
+        set { _fameLastWeek = value; OnPropertyChanged(); }
+    }
+
+    public double SilverLastWeek
+    {
+        get => _silverLastWeek;
+        set { _silverLastWeek = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecLastWeek
+    {
+        get => _reSpecLastWeek;
+        set { _reSpecLastWeek = value; OnPropertyChanged(); }
+    }
+
+    public double MightLastWeek
+    {
+        get => _mightLastWeek;
+        set { _mightLastWeek = value; OnPropertyChanged(); }
+    }
+
+    public double FavorLastWeek
+    {
+        get => _favorLastWeek;
+        set { _favorLastWeek = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameLastWeek
+    {
+        get => _factionFameLastWeek;
+        set { _factionFameLastWeek = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueLastWeek
+    {
+        get => _gatheringValueLastWeek;
+        set { _gatheringValueLastWeek = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region This Month
+
+    public double FameThisMonth
+    {
+        get => _fameThisMonth;
+        set { _fameThisMonth = value; OnPropertyChanged(); }
+    }
+
+    public double SilverThisMonth
+    {
+        get => _silverThisMonth;
+        set { _silverThisMonth = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecThisMonth
+    {
+        get => _reSpecThisMonth;
+        set { _reSpecThisMonth = value; OnPropertyChanged(); }
+    }
+
+    public double MightThisMonth
+    {
+        get => _mightThisMonth;
+        set { _mightThisMonth = value; OnPropertyChanged(); }
+    }
+
+    public double FavorThisMonth
+    {
+        get => _favorThisMonth;
+        set { _favorThisMonth = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameThisMonth
+    {
+        get => _factionFameThisMonth;
+        set { _factionFameThisMonth = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueThisMonth
+    {
+        get => _gatheringValueThisMonth;
+        set { _gatheringValueThisMonth = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region Last Month
+
+    public double FameLastMonth
+    {
+        get => _fameLastMonth;
+        set { _fameLastMonth = value; OnPropertyChanged(); }
+    }
+
+    public double SilverLastMonth
+    {
+        get => _silverLastMonth;
+        set { _silverLastMonth = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecLastMonth
+    {
+        get => _reSpecLastMonth;
+        set { _reSpecLastMonth = value; OnPropertyChanged(); }
+    }
+
+    public double MightLastMonth
+    {
+        get => _mightLastMonth;
+        set { _mightLastMonth = value; OnPropertyChanged(); }
+    }
+
+    public double FavorLastMonth
+    {
+        get => _favorLastMonth;
+        set { _favorLastMonth = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameLastMonth
+    {
+        get => _factionFameLastMonth;
+        set { _factionFameLastMonth = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueLastMonth
+    {
+        get => _gatheringValueLastMonth;
+        set { _gatheringValueLastMonth = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region This Year
+
+    public double FameThisYear
+    {
+        get => _fameThisYear;
+        set { _fameThisYear = value; OnPropertyChanged(); }
+    }
+
+    public double SilverThisYear
+    {
+        get => _silverThisYear;
+        set { _silverThisYear = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecThisYear
+    {
+        get => _reSpecThisYear;
+        set { _reSpecThisYear = value; OnPropertyChanged(); }
+    }
+
+    public double MightThisYear
+    {
+        get => _mightThisYear;
+        set { _mightThisYear = value; OnPropertyChanged(); }
+    }
+
+    public double FavorThisYear
+    {
+        get => _favorThisYear;
+        set { _favorThisYear = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameThisYear
+    {
+        get => _factionFameThisYear;
+        set { _factionFameThisYear = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueThisYear
+    {
+        get => _gatheringValueThisYear;
+        set { _gatheringValueThisYear = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region Total
+
+    public double FameTotal
+    {
+        get => _fameTotal;
+        set { _fameTotal = value; OnPropertyChanged(); }
+    }
+
+    public double SilverTotal
+    {
+        get => _silverTotal;
+        set { _silverTotal = value; OnPropertyChanged(); }
+    }
+
+    public double ReSpecTotal
+    {
+        get => _reSpecTotal;
+        set { _reSpecTotal = value; OnPropertyChanged(); }
+    }
+
+    public double MightTotal
+    {
+        get => _mightTotal;
+        set { _mightTotal = value; OnPropertyChanged(); }
+    }
+
+    public double FavorTotal
+    {
+        get => _favorTotal;
+        set { _favorTotal = value; OnPropertyChanged(); }
+    }
+
+    public double FactionFameTotal
+    {
+        get => _factionFameTotal;
+        set { _factionFameTotal = value; OnPropertyChanged(); }
+    }
+
+    public double GatheringValueTotal
+    {
+        get => _gatheringValueTotal;
+        set { _gatheringValueTotal = value; OnPropertyChanged(); }
+    }
+
+    #endregion
+
+    #region Translations – row labels
+
+    public static string TranslationToday => LocalizationController.Translation("TODAY");
+    public static string TranslationThisWeek => LocalizationController.Translation("THIS_WEEK");
+    public static string TranslationLastWeek => LocalizationController.Translation("LAST_WEEK");
+    public static string TranslationThisMonth => LocalizationController.Translation("MONTH");
+    public static string TranslationLastMonth => LocalizationController.Translation("LAST_MONTH");
+    public static string TranslationThisYear => LocalizationController.Translation("YEAR");
+    public static string TranslationTotal => LocalizationController.Translation("TOTAL");
+
+    #endregion
+
+    #region Translations – column headers
+
+    public static string TranslationFame => LocalizationController.Translation("FAME");
+    public static string TranslationSilver => LocalizationController.Translation("SILVER");
+    public static string TranslationReSpec => LocalizationController.Translation("RESPEC");
+    public static string TranslationMight => LocalizationController.Translation("MIGHT");
+    public static string TranslationFavor => LocalizationController.Translation("FAVOR");
+    public static string TranslationFaction => LocalizationController.Translation("FACTION");
+
+    #endregion
+
+    #region Backing fields — Today per hour
+
+    private double _fameTodayPerHour;
+    private double _silverTodayPerHour;
+    private double _reSpecTodayPerHour;
+    private double _mightTodayPerHour;
+    private double _favorTodayPerHour;
+    private double _factionFameTodayPerHour;
+    private double _gatheringValueTodayPerHour;
+
+    #endregion
+
+    #region Backing fields — This Week per hour
+
+    private double _fameThisWeekPerHour;
+    private double _silverThisWeekPerHour;
+    private double _reSpecThisWeekPerHour;
+    private double _mightThisWeekPerHour;
+    private double _favorThisWeekPerHour;
+    private double _factionFameThisWeekPerHour;
+    private double _gatheringValueThisWeekPerHour;
+
+    #endregion
+
+    #region Backing fields — Last Week per hour
+
+    private double _fameLastWeekPerHour;
+    private double _silverLastWeekPerHour;
+    private double _reSpecLastWeekPerHour;
+    private double _mightLastWeekPerHour;
+    private double _favorLastWeekPerHour;
+    private double _factionFameLastWeekPerHour;
+    private double _gatheringValueLastWeekPerHour;
+
+    #endregion
+
+    #region Backing fields — This Month per hour
+
+    private double _fameThisMonthPerHour;
+    private double _silverThisMonthPerHour;
+    private double _reSpecThisMonthPerHour;
+    private double _mightThisMonthPerHour;
+    private double _favorThisMonthPerHour;
+    private double _factionFameThisMonthPerHour;
+    private double _gatheringValueThisMonthPerHour;
+
+    #endregion
+
+    #region Backing fields — Last Month per hour
+
+    private double _fameLastMonthPerHour;
+    private double _silverLastMonthPerHour;
+    private double _reSpecLastMonthPerHour;
+    private double _mightLastMonthPerHour;
+    private double _favorLastMonthPerHour;
+    private double _factionFameLastMonthPerHour;
+    private double _gatheringValueLastMonthPerHour;
+
+    #endregion
+
+    #region Backing fields — This Year per hour
+
+    private double _fameThisYearPerHour;
+    private double _silverThisYearPerHour;
+    private double _reSpecThisYearPerHour;
+    private double _mightThisYearPerHour;
+    private double _favorThisYearPerHour;
+    private double _factionFameThisYearPerHour;
+    private double _gatheringValueThisYearPerHour;
+
+    #endregion
+
+    #region Backing fields — Total per hour
+
+    private double _fameTotalPerHour;
+    private double _silverTotalPerHour;
+    private double _reSpecTotalPerHour;
+    private double _mightTotalPerHour;
+    private double _favorTotalPerHour;
+    private double _factionFameTotalPerHour;
+    private double _gatheringValueTotalPerHour;
+
+    #endregion
+
+    #region Backing fields — Session
+
+    private double _fameSession;
+    private double _silverSession;
+    private double _reSpecSession;
+    private double _mightSession;
+    private double _favorSession;
+    private double _factionFameSession;
+    private double _fameSessionPerHour;
+    private double _silverSessionPerHour;
+    private double _reSpecSessionPerHour;
+    private double _mightSessionPerHour;
+    private double _favorSessionPerHour;
+    private double _factionFameSessionPerHour;
+    private double _gatheringValueSession;
+    private double _gatheringValueSessionPerHour;
+    private CityFaction _cityFaction;
+    private string _activeTimeSession = string.Empty;
+    private string _activeTimeToday = string.Empty;
+    private string _activeTimeThisWeek = string.Empty;
+    private string _activeTimeLastWeek = string.Empty;
+    private string _activeTimeThisMonth = string.Empty;
+    private string _activeTimeLastMonth = string.Empty;
+    private string _activeTimeThisYear = string.Empty;
+    private string _activeTimeTotal = string.Empty;
+
+    #endregion
+
+    #region Today per hour
+
+    public double FameTodayPerHour { get => _fameTodayPerHour; set { _fameTodayPerHour = value; OnPropertyChanged(); } }
+    public double SilverTodayPerHour { get => _silverTodayPerHour; set { _silverTodayPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecTodayPerHour { get => _reSpecTodayPerHour; set { _reSpecTodayPerHour = value; OnPropertyChanged(); } }
+    public double MightTodayPerHour { get => _mightTodayPerHour; set { _mightTodayPerHour = value; OnPropertyChanged(); } }
+    public double FavorTodayPerHour { get => _favorTodayPerHour; set { _favorTodayPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameTodayPerHour { get => _factionFameTodayPerHour; set { _factionFameTodayPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueTodayPerHour { get => _gatheringValueTodayPerHour; set { _gatheringValueTodayPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region This Week per hour
+
+    public double FameThisWeekPerHour { get => _fameThisWeekPerHour; set { _fameThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double SilverThisWeekPerHour { get => _silverThisWeekPerHour; set { _silverThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecThisWeekPerHour { get => _reSpecThisWeekPerHour; set { _reSpecThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double MightThisWeekPerHour { get => _mightThisWeekPerHour; set { _mightThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double FavorThisWeekPerHour { get => _favorThisWeekPerHour; set { _favorThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameThisWeekPerHour { get => _factionFameThisWeekPerHour; set { _factionFameThisWeekPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueThisWeekPerHour { get => _gatheringValueThisWeekPerHour; set { _gatheringValueThisWeekPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region Last Week per hour
+
+    public double FameLastWeekPerHour { get => _fameLastWeekPerHour; set { _fameLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double SilverLastWeekPerHour { get => _silverLastWeekPerHour; set { _silverLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecLastWeekPerHour { get => _reSpecLastWeekPerHour; set { _reSpecLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double MightLastWeekPerHour { get => _mightLastWeekPerHour; set { _mightLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double FavorLastWeekPerHour { get => _favorLastWeekPerHour; set { _favorLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameLastWeekPerHour { get => _factionFameLastWeekPerHour; set { _factionFameLastWeekPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueLastWeekPerHour { get => _gatheringValueLastWeekPerHour; set { _gatheringValueLastWeekPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region This Month per hour
+
+    public double FameThisMonthPerHour { get => _fameThisMonthPerHour; set { _fameThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double SilverThisMonthPerHour { get => _silverThisMonthPerHour; set { _silverThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecThisMonthPerHour { get => _reSpecThisMonthPerHour; set { _reSpecThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double MightThisMonthPerHour { get => _mightThisMonthPerHour; set { _mightThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double FavorThisMonthPerHour { get => _favorThisMonthPerHour; set { _favorThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameThisMonthPerHour { get => _factionFameThisMonthPerHour; set { _factionFameThisMonthPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueThisMonthPerHour { get => _gatheringValueThisMonthPerHour; set { _gatheringValueThisMonthPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region Last Month per hour
+
+    public double FameLastMonthPerHour { get => _fameLastMonthPerHour; set { _fameLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double SilverLastMonthPerHour { get => _silverLastMonthPerHour; set { _silverLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecLastMonthPerHour { get => _reSpecLastMonthPerHour; set { _reSpecLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double MightLastMonthPerHour { get => _mightLastMonthPerHour; set { _mightLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double FavorLastMonthPerHour { get => _favorLastMonthPerHour; set { _favorLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameLastMonthPerHour { get => _factionFameLastMonthPerHour; set { _factionFameLastMonthPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueLastMonthPerHour { get => _gatheringValueLastMonthPerHour; set { _gatheringValueLastMonthPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region This Year per hour
+
+    public double FameThisYearPerHour { get => _fameThisYearPerHour; set { _fameThisYearPerHour = value; OnPropertyChanged(); } }
+    public double SilverThisYearPerHour { get => _silverThisYearPerHour; set { _silverThisYearPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecThisYearPerHour { get => _reSpecThisYearPerHour; set { _reSpecThisYearPerHour = value; OnPropertyChanged(); } }
+    public double MightThisYearPerHour { get => _mightThisYearPerHour; set { _mightThisYearPerHour = value; OnPropertyChanged(); } }
+    public double FavorThisYearPerHour { get => _favorThisYearPerHour; set { _favorThisYearPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameThisYearPerHour { get => _factionFameThisYearPerHour; set { _factionFameThisYearPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueThisYearPerHour { get => _gatheringValueThisYearPerHour; set { _gatheringValueThisYearPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region Total per hour
+
+    public double FameTotalPerHour { get => _fameTotalPerHour; set { _fameTotalPerHour = value; OnPropertyChanged(); } }
+    public double SilverTotalPerHour { get => _silverTotalPerHour; set { _silverTotalPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecTotalPerHour { get => _reSpecTotalPerHour; set { _reSpecTotalPerHour = value; OnPropertyChanged(); } }
+    public double MightTotalPerHour { get => _mightTotalPerHour; set { _mightTotalPerHour = value; OnPropertyChanged(); } }
+    public double FavorTotalPerHour { get => _favorTotalPerHour; set { _favorTotalPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameTotalPerHour { get => _factionFameTotalPerHour; set { _factionFameTotalPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueTotalPerHour { get => _gatheringValueTotalPerHour; set { _gatheringValueTotalPerHour = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    #region Session
+
+    public double FameSession { get => _fameSession; set { _fameSession = value; OnPropertyChanged(); } }
+    public double SilverSession { get => _silverSession; set { _silverSession = value; OnPropertyChanged(); } }
+    public double ReSpecSession { get => _reSpecSession; set { _reSpecSession = value; OnPropertyChanged(); } }
+    public double MightSession { get => _mightSession; set { _mightSession = value; OnPropertyChanged(); } }
+    public double FavorSession { get => _favorSession; set { _favorSession = value; OnPropertyChanged(); } }
+    public double FactionFameSession { get => _factionFameSession; set { _factionFameSession = value; OnPropertyChanged(); } }
+    public double FameSessionPerHour { get => _fameSessionPerHour; set { _fameSessionPerHour = value; OnPropertyChanged(); } }
+    public double SilverSessionPerHour { get => _silverSessionPerHour; set { _silverSessionPerHour = value; OnPropertyChanged(); } }
+    public double ReSpecSessionPerHour { get => _reSpecSessionPerHour; set { _reSpecSessionPerHour = value; OnPropertyChanged(); } }
+    public double MightSessionPerHour { get => _mightSessionPerHour; set { _mightSessionPerHour = value; OnPropertyChanged(); } }
+    public double FavorSessionPerHour { get => _favorSessionPerHour; set { _favorSessionPerHour = value; OnPropertyChanged(); } }
+    public double FactionFameSessionPerHour { get => _factionFameSessionPerHour; set { _factionFameSessionPerHour = value; OnPropertyChanged(); } }
+    public double GatheringValueSession { get => _gatheringValueSession; set { _gatheringValueSession = value; OnPropertyChanged(); } }
+    public double GatheringValueSessionPerHour { get => _gatheringValueSessionPerHour; set { _gatheringValueSessionPerHour = value; OnPropertyChanged(); } }
+    public CityFaction CityFaction { get => _cityFaction; set { _cityFaction = value; OnPropertyChanged(); } }
+    public string ActiveTimeSession { get => _activeTimeSession; set { _activeTimeSession = value; OnPropertyChanged(); } }
+    public string ActiveTimeToday { get => _activeTimeToday; set { _activeTimeToday = value; OnPropertyChanged(); } }
+    public string ActiveTimeThisWeek { get => _activeTimeThisWeek; set { _activeTimeThisWeek = value; OnPropertyChanged(); } }
+    public string ActiveTimeLastWeek { get => _activeTimeLastWeek; set { _activeTimeLastWeek = value; OnPropertyChanged(); } }
+    public string ActiveTimeThisMonth { get => _activeTimeThisMonth; set { _activeTimeThisMonth = value; OnPropertyChanged(); } }
+    public string ActiveTimeLastMonth { get => _activeTimeLastMonth; set { _activeTimeLastMonth = value; OnPropertyChanged(); } }
+    public string ActiveTimeThisYear { get => _activeTimeThisYear; set { _activeTimeThisYear = value; OnPropertyChanged(); } }
+    public string ActiveTimeTotal { get => _activeTimeTotal; set { _activeTimeTotal = value; OnPropertyChanged(); } }
+
+    #endregion
+
+    public static string TranslationSession => LocalizationController.Translation("SESSION");
+    public static string TranslationGatheringValue => LocalizationController.Translation("GATHERING");
+}

--- a/src/StatisticsAnalysisTool/Network/LiveStatsTracker.cs
+++ b/src/StatisticsAnalysisTool/Network/LiveStatsTracker.cs
@@ -88,8 +88,10 @@ public class LiveStatsTracker
     private readonly SlidingWindow _favorWin = new();
     private readonly SlidingWindow _respecCostWin = new();
     private readonly SlidingWindow _factionPointsWin = new();
+    private readonly SlidingWindow _gatheringValueWin = new();
 
     private DateTime _sessionStartUtc;
+    public DateTime SessionStartUtc => _sessionStartUtc;
     private double _totalGainedFameInSession;
     private double _totalGainedReSpecInSession;
     private double _totalGainedSilverInSession;
@@ -97,6 +99,7 @@ public class LiveStatsTracker
     private double _totalGainedFavorInSession;
     private double _totalPaidSilverForReSpecInSession;
     private double _totalGainedFactionPointsInSession;
+    private double _totalGatheredValueInSession;
 
     private CityFaction _currentCityFaction = CityFaction.Unknown;
 
@@ -152,6 +155,11 @@ public class LiveStatsTracker
                 _favorWin.Add(value, now);
                 break;
 
+            case ValueType.GatheringValue:
+                _totalGatheredValueInSession += value;
+                _gatheringValueWin.Add(value, now);
+                break;
+
             case ValueType.PaidSilverForReSpec:
                 _totalPaidSilverForReSpecInSession += value;
                 _respecCostWin.Add(value, now);
@@ -188,6 +196,7 @@ public class LiveStatsTracker
         _favorWin.Clear();
         _respecCostWin.Clear();
         _factionPointsWin.Clear();
+        _gatheringValueWin.Clear();
 
         _totalGainedFameInSession = 0;
         _totalGainedReSpecInSession = 0;
@@ -196,6 +205,7 @@ public class LiveStatsTracker
         _totalGainedFavorInSession = 0;
         _totalPaidSilverForReSpecInSession = 0;
         _totalGainedFactionPointsInSession = 0;
+        _totalGatheredValueInSession = 0;
         _currentCityFaction = CityFaction.Unknown;
 
         _mainWindowViewModel.DashboardBindings.Reset();
@@ -231,6 +241,7 @@ public class LiveStatsTracker
         var (favorSum, favorSec) = _favorWin.Snapshot(now);
         var (respecCostSum, respecCostSec) = _respecCostWin.Snapshot(now);
         var (factionSum, factionSec) = _factionPointsWin.Snapshot(now);
+        var (gatheringSum, gatheringSec) = _gatheringValueWin.Snapshot(now);
 
         // Per hour
         _mainWindowViewModel.DashboardBindings.FamePerHour = fameSum * 3600.0 / fameSec;
@@ -239,6 +250,8 @@ public class LiveStatsTracker
         _mainWindowViewModel.DashboardBindings.MightPerHour = mightSum * 3600.0 / mightSec;
         _mainWindowViewModel.DashboardBindings.FavorPerHour = favorSum * 3600.0 / favorSec;
         _mainWindowViewModel.DashboardBindings.SilverCostForReSpecHour = respecCostSum * 3600.0 / respecCostSec;
+        _mainWindowViewModel.DashboardBindings.TotalGatheredValueInSession = _totalGatheredValueInSession;
+        _mainWindowViewModel.DashboardBindings.GatheringValuePerHour = gatheringSum * 3600.0 / gatheringSec;
 
         var factionPointStat = _mainWindowViewModel.FactionPointStats.FirstOrDefault();
         if (factionPointStat != null)
@@ -248,8 +261,15 @@ public class LiveStatsTracker
             factionPointStat.Value = _totalGainedFactionPointsInSession;
         }
 
-        // Session-Timer
+        // Session-Timer — uses total hours so sessions longer than 24h display correctly
         var duration = now - _sessionStartUtc;
-        _mainWindowViewModel.MainTrackerTimer = duration.ToString("hh\\:mm\\:ss");
+        _mainWindowViewModel.MainTrackerTimer = $"{(int) duration.TotalHours:D2}:{duration.Minutes:D2}:{duration.Seconds:D2}";
+
+        if (_trackingController.IsTrackingAllowedByMainCharacter())
+        {
+            _trackingController.StatisticController?.AddActiveTime(2);
+        }
+
+        _trackingController.StatisticController?.UpdateLifetimeStatsUi();
     }
 }

--- a/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
@@ -299,13 +299,13 @@ public class StatisticController
         stats.ReSpecToday = SumValue(ValueType.ReSpec, todayStart, now);
         stats.MightToday = SumValue(ValueType.Might, todayStart, now);
         stats.FavorToday = SumValue(ValueType.Favor, todayStart, now);
-        stats.FactionFameToday = SumValue(ValueType.FactionFame, todayStart, now);
+        stats.FactionPointsToday = SumValue(ValueType.FactionPoints, todayStart, now);
         stats.FameTodayPerHour = PerHour(stats.FameToday, todayHours);
         stats.SilverTodayPerHour = PerHour(stats.SilverToday, todayHours);
         stats.ReSpecTodayPerHour = PerHour(stats.ReSpecToday, todayHours);
         stats.MightTodayPerHour = PerHour(stats.MightToday, todayHours);
         stats.FavorTodayPerHour = PerHour(stats.FavorToday, todayHours);
-        stats.FactionFameTodayPerHour = PerHour(stats.FactionFameToday, todayHours);
+        stats.FactionPointsTodayPerHour = PerHour(stats.FactionPointsToday, todayHours);
         stats.GatheringValueToday = SumValue(ValueType.GatheringValue, todayStart, now);
         stats.GatheringValueTodayPerHour = PerHour(stats.GatheringValueToday, todayHours);
 
@@ -316,13 +316,13 @@ public class StatisticController
         stats.ReSpecThisWeek = SumValue(ValueType.ReSpec, thisWeekStart, now);
         stats.MightThisWeek = SumValue(ValueType.Might, thisWeekStart, now);
         stats.FavorThisWeek = SumValue(ValueType.Favor, thisWeekStart, now);
-        stats.FactionFameThisWeek = SumValue(ValueType.FactionFame, thisWeekStart, now);
+        stats.FactionPointsThisWeek = SumValue(ValueType.FactionPoints, thisWeekStart, now);
         stats.FameThisWeekPerHour = PerHour(stats.FameThisWeek, thisWeekHours);
         stats.SilverThisWeekPerHour = PerHour(stats.SilverThisWeek, thisWeekHours);
         stats.ReSpecThisWeekPerHour = PerHour(stats.ReSpecThisWeek, thisWeekHours);
         stats.MightThisWeekPerHour = PerHour(stats.MightThisWeek, thisWeekHours);
         stats.FavorThisWeekPerHour = PerHour(stats.FavorThisWeek, thisWeekHours);
-        stats.FactionFameThisWeekPerHour = PerHour(stats.FactionFameThisWeek, thisWeekHours);
+        stats.FactionPointsThisWeekPerHour = PerHour(stats.FactionPointsThisWeek, thisWeekHours);
         stats.GatheringValueThisWeek = SumValue(ValueType.GatheringValue, thisWeekStart, now);
         stats.GatheringValueThisWeekPerHour = PerHour(stats.GatheringValueThisWeek, thisWeekHours);
 
@@ -333,13 +333,13 @@ public class StatisticController
         stats.ReSpecLastWeek = SumValue(ValueType.ReSpec, lastWeekStart, lastWeekEnd);
         stats.MightLastWeek = SumValue(ValueType.Might, lastWeekStart, lastWeekEnd);
         stats.FavorLastWeek = SumValue(ValueType.Favor, lastWeekStart, lastWeekEnd);
-        stats.FactionFameLastWeek = SumValue(ValueType.FactionFame, lastWeekStart, lastWeekEnd);
+        stats.FactionPointsLastWeek = SumValue(ValueType.FactionPoints, lastWeekStart, lastWeekEnd);
         stats.FameLastWeekPerHour = PerHour(stats.FameLastWeek, lastWeekHours);
         stats.SilverLastWeekPerHour = PerHour(stats.SilverLastWeek, lastWeekHours);
         stats.ReSpecLastWeekPerHour = PerHour(stats.ReSpecLastWeek, lastWeekHours);
         stats.MightLastWeekPerHour = PerHour(stats.MightLastWeek, lastWeekHours);
         stats.FavorLastWeekPerHour = PerHour(stats.FavorLastWeek, lastWeekHours);
-        stats.FactionFameLastWeekPerHour = PerHour(stats.FactionFameLastWeek, lastWeekHours);
+        stats.FactionPointsLastWeekPerHour = PerHour(stats.FactionPointsLastWeek, lastWeekHours);
         stats.GatheringValueLastWeek = SumValue(ValueType.GatheringValue, lastWeekStart, lastWeekEnd);
         stats.GatheringValueLastWeekPerHour = PerHour(stats.GatheringValueLastWeek, lastWeekHours);
 
@@ -350,13 +350,13 @@ public class StatisticController
         stats.ReSpecThisMonth = SumValue(ValueType.ReSpec, thisMonthStart, now);
         stats.MightThisMonth = SumValue(ValueType.Might, thisMonthStart, now);
         stats.FavorThisMonth = SumValue(ValueType.Favor, thisMonthStart, now);
-        stats.FactionFameThisMonth = SumValue(ValueType.FactionFame, thisMonthStart, now);
+        stats.FactionPointsThisMonth = SumValue(ValueType.FactionPoints, thisMonthStart, now);
         stats.FameThisMonthPerHour = PerHour(stats.FameThisMonth, thisMonthHours);
         stats.SilverThisMonthPerHour = PerHour(stats.SilverThisMonth, thisMonthHours);
         stats.ReSpecThisMonthPerHour = PerHour(stats.ReSpecThisMonth, thisMonthHours);
         stats.MightThisMonthPerHour = PerHour(stats.MightThisMonth, thisMonthHours);
         stats.FavorThisMonthPerHour = PerHour(stats.FavorThisMonth, thisMonthHours);
-        stats.FactionFameThisMonthPerHour = PerHour(stats.FactionFameThisMonth, thisMonthHours);
+        stats.FactionPointsThisMonthPerHour = PerHour(stats.FactionPointsThisMonth, thisMonthHours);
         stats.GatheringValueThisMonth = SumValue(ValueType.GatheringValue, thisMonthStart, now);
         stats.GatheringValueThisMonthPerHour = PerHour(stats.GatheringValueThisMonth, thisMonthHours);
 
@@ -367,13 +367,13 @@ public class StatisticController
         stats.ReSpecLastMonth = SumValue(ValueType.ReSpec, lastMonthStart, lastMonthEnd);
         stats.MightLastMonth = SumValue(ValueType.Might, lastMonthStart, lastMonthEnd);
         stats.FavorLastMonth = SumValue(ValueType.Favor, lastMonthStart, lastMonthEnd);
-        stats.FactionFameLastMonth = SumValue(ValueType.FactionFame, lastMonthStart, lastMonthEnd);
+        stats.FactionPointsLastMonth = SumValue(ValueType.FactionPoints, lastMonthStart, lastMonthEnd);
         stats.FameLastMonthPerHour = PerHour(stats.FameLastMonth, lastMonthHours);
         stats.SilverLastMonthPerHour = PerHour(stats.SilverLastMonth, lastMonthHours);
         stats.ReSpecLastMonthPerHour = PerHour(stats.ReSpecLastMonth, lastMonthHours);
         stats.MightLastMonthPerHour = PerHour(stats.MightLastMonth, lastMonthHours);
         stats.FavorLastMonthPerHour = PerHour(stats.FavorLastMonth, lastMonthHours);
-        stats.FactionFameLastMonthPerHour = PerHour(stats.FactionFameLastMonth, lastMonthHours);
+        stats.FactionPointsLastMonthPerHour = PerHour(stats.FactionPointsLastMonth, lastMonthHours);
         stats.GatheringValueLastMonth = SumValue(ValueType.GatheringValue, lastMonthStart, lastMonthEnd);
         stats.GatheringValueLastMonthPerHour = PerHour(stats.GatheringValueLastMonth, lastMonthHours);
 
@@ -384,13 +384,13 @@ public class StatisticController
         stats.ReSpecThisYear = SumValue(ValueType.ReSpec, thisYearStart, now);
         stats.MightThisYear = SumValue(ValueType.Might, thisYearStart, now);
         stats.FavorThisYear = SumValue(ValueType.Favor, thisYearStart, now);
-        stats.FactionFameThisYear = SumValue(ValueType.FactionFame, thisYearStart, now);
+        stats.FactionPointsThisYear = SumValue(ValueType.FactionPoints, thisYearStart, now);
         stats.FameThisYearPerHour = PerHour(stats.FameThisYear, thisYearHours);
         stats.SilverThisYearPerHour = PerHour(stats.SilverThisYear, thisYearHours);
         stats.ReSpecThisYearPerHour = PerHour(stats.ReSpecThisYear, thisYearHours);
         stats.MightThisYearPerHour = PerHour(stats.MightThisYear, thisYearHours);
         stats.FavorThisYearPerHour = PerHour(stats.FavorThisYear, thisYearHours);
-        stats.FactionFameThisYearPerHour = PerHour(stats.FactionFameThisYear, thisYearHours);
+        stats.FactionPointsThisYearPerHour = PerHour(stats.FactionPointsThisYear, thisYearHours);
         stats.GatheringValueThisYear = SumValue(ValueType.GatheringValue, thisYearStart, now);
         stats.GatheringValueThisYearPerHour = PerHour(stats.GatheringValueThisYear, thisYearHours);
 
@@ -401,13 +401,13 @@ public class StatisticController
         stats.ReSpecTotal = SumValue(ValueType.ReSpec, DateTime.MinValue, now);
         stats.MightTotal = SumValue(ValueType.Might, DateTime.MinValue, now);
         stats.FavorTotal = SumValue(ValueType.Favor, DateTime.MinValue, now);
-        stats.FactionFameTotal = SumValue(ValueType.FactionFame, DateTime.MinValue, now);
+        stats.FactionPointsTotal = SumValue(ValueType.FactionPoints, DateTime.MinValue, now);
         stats.FameTotalPerHour = PerHour(stats.FameTotal, totalHours);
         stats.SilverTotalPerHour = PerHour(stats.SilverTotal, totalHours);
         stats.ReSpecTotalPerHour = PerHour(stats.ReSpecTotal, totalHours);
         stats.MightTotalPerHour = PerHour(stats.MightTotal, totalHours);
         stats.FavorTotalPerHour = PerHour(stats.FavorTotal, totalHours);
-        stats.FactionFameTotalPerHour = PerHour(stats.FactionFameTotal, totalHours);
+        stats.FactionPointsTotalPerHour = PerHour(stats.FactionPointsTotal, totalHours);
         stats.GatheringValueTotal = SumValue(ValueType.GatheringValue, DateTime.MinValue, now);
         stats.GatheringValueTotalPerHour = PerHour(stats.GatheringValueTotal, totalHours);
 
@@ -419,13 +419,13 @@ public class StatisticController
         stats.FavorSession = bindings.TotalGainedFavorInSession;
         stats.GatheringValueSession = bindings.TotalGatheredValueInSession;
         stats.GatheringValueSessionPerHour = bindings.GatheringValuePerHour;
-        stats.FactionFameSession = 0;
+        stats.FactionPointsSession = _mainWindowViewModel.FactionPointStats.FirstOrDefault()?.Value ?? 0;
         stats.FameSessionPerHour = bindings.FamePerHour;
         stats.SilverSessionPerHour = bindings.SilverPerHour;
         stats.ReSpecSessionPerHour = bindings.ReSpecPointsPerHour;
         stats.MightSessionPerHour = bindings.MightPerHour;
         stats.FavorSessionPerHour = bindings.FavorPerHour;
-        stats.FactionFameSessionPerHour = 0;
+        stats.FactionPointsSessionPerHour = _mainWindowViewModel.FactionPointStats.FirstOrDefault()?.ValuePerHour ?? 0;
         stats.CityFaction = _mainWindowViewModel.FactionPointStats.FirstOrDefault()?.CityFaction ?? CityFaction.Unknown;
 
         // Active time labels per period

--- a/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
@@ -24,8 +24,6 @@ namespace StatisticsAnalysisTool.Network.Manager;
 
 public class StatisticController
 {
-
-
     private readonly TrackingController _trackingController;
     private readonly MainWindowViewModel _mainWindowViewModel;
     private readonly List<ValueType> _valueTypes = new()

--- a/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
+++ b/src/StatisticsAnalysisTool/Network/Manager/StatisticController.cs
@@ -17,6 +17,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Media;
+using CityFaction = StatisticsAnalysisTool.Enumerations.CityFaction;
 using ValueType = StatisticsAnalysisTool.Enumerations.ValueType;
 
 namespace StatisticsAnalysisTool.Network.Manager;
@@ -29,7 +30,7 @@ public class StatisticController
     private readonly MainWindowViewModel _mainWindowViewModel;
     private readonly List<ValueType> _valueTypes = new()
     {
-        ValueType.Fame, ValueType.Silver, ValueType.ReSpec, ValueType.FactionFame, ValueType.FactionPoints, ValueType.Might, ValueType.Favor, ValueType.RepairCosts
+        ValueType.Fame, ValueType.Silver, ValueType.ReSpec, ValueType.FactionFame, ValueType.FactionPoints, ValueType.Might, ValueType.Favor, ValueType.RepairCosts, ValueType.GatheringValue
     };
 
     private DateTime _lastChartUpdate;
@@ -44,6 +45,7 @@ public class StatisticController
         InitStartHourValues();
 
         OnAddValue += UpdateRepairCostsUi;
+        OnAddValue += UpdateLifetimeStatsUi;
     }
 
     #region Dashboard
@@ -78,6 +80,11 @@ public class StatisticController
 
         _dashboardStatistics.Add(new DailyValues(valueType, gainedValue, DateTime.Now));
         OnAddValue?.Invoke();
+    }
+
+    public void AddActiveTime(double seconds)
+    {
+        _dashboardStatistics.Add(new DailyValues(ValueType.ActiveTime, seconds, DateTime.Now));
     }
 
     private void UpdateDailyChart(ObservableCollection<DashboardHourObject> stats)
@@ -266,6 +273,205 @@ public class StatisticController
             .Sum(x => FixPoint.FromFloatingPointValue(x.Value).IntegerValue);
     }
 
+    public void UpdateLifetimeStatsUi()
+    {
+        if (_dashboardStatistics?.DailyValues == null)
+        {
+            return;
+        }
+
+        var stats = _mainWindowViewModel.DashboardBindings.LifetimeStats;
+        var bindings = _mainWindowViewModel.DashboardBindings;
+        var now = DateTime.Now;
+
+        var todayStart = now.Date;
+        var thisWeekStart = now.Date.AddDays(-(int) now.DayOfWeek == 0 ? 6 : (int) now.DayOfWeek - 1);
+        if (thisWeekStart > now.Date) thisWeekStart = thisWeekStart.AddDays(-7);
+        var lastWeekStart = thisWeekStart.AddDays(-7);
+        var lastWeekEnd = thisWeekStart;
+        var thisMonthStart = new DateTime(now.Year, now.Month, 1);
+        var lastMonthStart = thisMonthStart.AddMonths(-1);
+        var lastMonthEnd = thisMonthStart;
+        var thisYearStart = new DateTime(now.Year, 1, 1);
+
+        // Today
+        var todayHours = SumActiveHours(todayStart, now);
+        stats.FameToday = SumValue(ValueType.Fame, todayStart, now);
+        stats.SilverToday = SumValue(ValueType.Silver, todayStart, now);
+        stats.ReSpecToday = SumValue(ValueType.ReSpec, todayStart, now);
+        stats.MightToday = SumValue(ValueType.Might, todayStart, now);
+        stats.FavorToday = SumValue(ValueType.Favor, todayStart, now);
+        stats.FactionFameToday = SumValue(ValueType.FactionFame, todayStart, now);
+        stats.FameTodayPerHour = PerHour(stats.FameToday, todayHours);
+        stats.SilverTodayPerHour = PerHour(stats.SilverToday, todayHours);
+        stats.ReSpecTodayPerHour = PerHour(stats.ReSpecToday, todayHours);
+        stats.MightTodayPerHour = PerHour(stats.MightToday, todayHours);
+        stats.FavorTodayPerHour = PerHour(stats.FavorToday, todayHours);
+        stats.FactionFameTodayPerHour = PerHour(stats.FactionFameToday, todayHours);
+        stats.GatheringValueToday = SumValue(ValueType.GatheringValue, todayStart, now);
+        stats.GatheringValueTodayPerHour = PerHour(stats.GatheringValueToday, todayHours);
+
+        // This Week
+        var thisWeekHours = SumActiveHours(thisWeekStart, now);
+        stats.FameThisWeek = SumValue(ValueType.Fame, thisWeekStart, now);
+        stats.SilverThisWeek = SumValue(ValueType.Silver, thisWeekStart, now);
+        stats.ReSpecThisWeek = SumValue(ValueType.ReSpec, thisWeekStart, now);
+        stats.MightThisWeek = SumValue(ValueType.Might, thisWeekStart, now);
+        stats.FavorThisWeek = SumValue(ValueType.Favor, thisWeekStart, now);
+        stats.FactionFameThisWeek = SumValue(ValueType.FactionFame, thisWeekStart, now);
+        stats.FameThisWeekPerHour = PerHour(stats.FameThisWeek, thisWeekHours);
+        stats.SilverThisWeekPerHour = PerHour(stats.SilverThisWeek, thisWeekHours);
+        stats.ReSpecThisWeekPerHour = PerHour(stats.ReSpecThisWeek, thisWeekHours);
+        stats.MightThisWeekPerHour = PerHour(stats.MightThisWeek, thisWeekHours);
+        stats.FavorThisWeekPerHour = PerHour(stats.FavorThisWeek, thisWeekHours);
+        stats.FactionFameThisWeekPerHour = PerHour(stats.FactionFameThisWeek, thisWeekHours);
+        stats.GatheringValueThisWeek = SumValue(ValueType.GatheringValue, thisWeekStart, now);
+        stats.GatheringValueThisWeekPerHour = PerHour(stats.GatheringValueThisWeek, thisWeekHours);
+
+        // Last Week
+        var lastWeekHours = SumActiveHours(lastWeekStart, lastWeekEnd);
+        stats.FameLastWeek = SumValue(ValueType.Fame, lastWeekStart, lastWeekEnd);
+        stats.SilverLastWeek = SumValue(ValueType.Silver, lastWeekStart, lastWeekEnd);
+        stats.ReSpecLastWeek = SumValue(ValueType.ReSpec, lastWeekStart, lastWeekEnd);
+        stats.MightLastWeek = SumValue(ValueType.Might, lastWeekStart, lastWeekEnd);
+        stats.FavorLastWeek = SumValue(ValueType.Favor, lastWeekStart, lastWeekEnd);
+        stats.FactionFameLastWeek = SumValue(ValueType.FactionFame, lastWeekStart, lastWeekEnd);
+        stats.FameLastWeekPerHour = PerHour(stats.FameLastWeek, lastWeekHours);
+        stats.SilverLastWeekPerHour = PerHour(stats.SilverLastWeek, lastWeekHours);
+        stats.ReSpecLastWeekPerHour = PerHour(stats.ReSpecLastWeek, lastWeekHours);
+        stats.MightLastWeekPerHour = PerHour(stats.MightLastWeek, lastWeekHours);
+        stats.FavorLastWeekPerHour = PerHour(stats.FavorLastWeek, lastWeekHours);
+        stats.FactionFameLastWeekPerHour = PerHour(stats.FactionFameLastWeek, lastWeekHours);
+        stats.GatheringValueLastWeek = SumValue(ValueType.GatheringValue, lastWeekStart, lastWeekEnd);
+        stats.GatheringValueLastWeekPerHour = PerHour(stats.GatheringValueLastWeek, lastWeekHours);
+
+        // This Month
+        var thisMonthHours = SumActiveHours(thisMonthStart, now);
+        stats.FameThisMonth = SumValue(ValueType.Fame, thisMonthStart, now);
+        stats.SilverThisMonth = SumValue(ValueType.Silver, thisMonthStart, now);
+        stats.ReSpecThisMonth = SumValue(ValueType.ReSpec, thisMonthStart, now);
+        stats.MightThisMonth = SumValue(ValueType.Might, thisMonthStart, now);
+        stats.FavorThisMonth = SumValue(ValueType.Favor, thisMonthStart, now);
+        stats.FactionFameThisMonth = SumValue(ValueType.FactionFame, thisMonthStart, now);
+        stats.FameThisMonthPerHour = PerHour(stats.FameThisMonth, thisMonthHours);
+        stats.SilverThisMonthPerHour = PerHour(stats.SilverThisMonth, thisMonthHours);
+        stats.ReSpecThisMonthPerHour = PerHour(stats.ReSpecThisMonth, thisMonthHours);
+        stats.MightThisMonthPerHour = PerHour(stats.MightThisMonth, thisMonthHours);
+        stats.FavorThisMonthPerHour = PerHour(stats.FavorThisMonth, thisMonthHours);
+        stats.FactionFameThisMonthPerHour = PerHour(stats.FactionFameThisMonth, thisMonthHours);
+        stats.GatheringValueThisMonth = SumValue(ValueType.GatheringValue, thisMonthStart, now);
+        stats.GatheringValueThisMonthPerHour = PerHour(stats.GatheringValueThisMonth, thisMonthHours);
+
+        // Last Month
+        var lastMonthHours = SumActiveHours(lastMonthStart, lastMonthEnd);
+        stats.FameLastMonth = SumValue(ValueType.Fame, lastMonthStart, lastMonthEnd);
+        stats.SilverLastMonth = SumValue(ValueType.Silver, lastMonthStart, lastMonthEnd);
+        stats.ReSpecLastMonth = SumValue(ValueType.ReSpec, lastMonthStart, lastMonthEnd);
+        stats.MightLastMonth = SumValue(ValueType.Might, lastMonthStart, lastMonthEnd);
+        stats.FavorLastMonth = SumValue(ValueType.Favor, lastMonthStart, lastMonthEnd);
+        stats.FactionFameLastMonth = SumValue(ValueType.FactionFame, lastMonthStart, lastMonthEnd);
+        stats.FameLastMonthPerHour = PerHour(stats.FameLastMonth, lastMonthHours);
+        stats.SilverLastMonthPerHour = PerHour(stats.SilverLastMonth, lastMonthHours);
+        stats.ReSpecLastMonthPerHour = PerHour(stats.ReSpecLastMonth, lastMonthHours);
+        stats.MightLastMonthPerHour = PerHour(stats.MightLastMonth, lastMonthHours);
+        stats.FavorLastMonthPerHour = PerHour(stats.FavorLastMonth, lastMonthHours);
+        stats.FactionFameLastMonthPerHour = PerHour(stats.FactionFameLastMonth, lastMonthHours);
+        stats.GatheringValueLastMonth = SumValue(ValueType.GatheringValue, lastMonthStart, lastMonthEnd);
+        stats.GatheringValueLastMonthPerHour = PerHour(stats.GatheringValueLastMonth, lastMonthHours);
+
+        // This Year
+        var thisYearHours = SumActiveHours(thisYearStart, now);
+        stats.FameThisYear = SumValue(ValueType.Fame, thisYearStart, now);
+        stats.SilverThisYear = SumValue(ValueType.Silver, thisYearStart, now);
+        stats.ReSpecThisYear = SumValue(ValueType.ReSpec, thisYearStart, now);
+        stats.MightThisYear = SumValue(ValueType.Might, thisYearStart, now);
+        stats.FavorThisYear = SumValue(ValueType.Favor, thisYearStart, now);
+        stats.FactionFameThisYear = SumValue(ValueType.FactionFame, thisYearStart, now);
+        stats.FameThisYearPerHour = PerHour(stats.FameThisYear, thisYearHours);
+        stats.SilverThisYearPerHour = PerHour(stats.SilverThisYear, thisYearHours);
+        stats.ReSpecThisYearPerHour = PerHour(stats.ReSpecThisYear, thisYearHours);
+        stats.MightThisYearPerHour = PerHour(stats.MightThisYear, thisYearHours);
+        stats.FavorThisYearPerHour = PerHour(stats.FavorThisYear, thisYearHours);
+        stats.FactionFameThisYearPerHour = PerHour(stats.FactionFameThisYear, thisYearHours);
+        stats.GatheringValueThisYear = SumValue(ValueType.GatheringValue, thisYearStart, now);
+        stats.GatheringValueThisYearPerHour = PerHour(stats.GatheringValueThisYear, thisYearHours);
+
+        // Total
+        var totalHours = SumActiveHours(DateTime.MinValue, now);
+        stats.FameTotal = SumValue(ValueType.Fame, DateTime.MinValue, now);
+        stats.SilverTotal = SumValue(ValueType.Silver, DateTime.MinValue, now);
+        stats.ReSpecTotal = SumValue(ValueType.ReSpec, DateTime.MinValue, now);
+        stats.MightTotal = SumValue(ValueType.Might, DateTime.MinValue, now);
+        stats.FavorTotal = SumValue(ValueType.Favor, DateTime.MinValue, now);
+        stats.FactionFameTotal = SumValue(ValueType.FactionFame, DateTime.MinValue, now);
+        stats.FameTotalPerHour = PerHour(stats.FameTotal, totalHours);
+        stats.SilverTotalPerHour = PerHour(stats.SilverTotal, totalHours);
+        stats.ReSpecTotalPerHour = PerHour(stats.ReSpecTotal, totalHours);
+        stats.MightTotalPerHour = PerHour(stats.MightTotal, totalHours);
+        stats.FavorTotalPerHour = PerHour(stats.FavorTotal, totalHours);
+        stats.FactionFameTotalPerHour = PerHour(stats.FactionFameTotal, totalHours);
+        stats.GatheringValueTotal = SumValue(ValueType.GatheringValue, DateTime.MinValue, now);
+        stats.GatheringValueTotalPerHour = PerHour(stats.GatheringValueTotal, totalHours);
+
+        // Session — mirror from DashboardBindings (maintained by LiveStatsTracker)
+        stats.FameSession = bindings.TotalGainedFameInSession;
+        stats.SilverSession = bindings.TotalGainedSilverInSession;
+        stats.ReSpecSession = bindings.TotalGainedReSpecPointsInSession;
+        stats.MightSession = bindings.TotalGainedMightInSession;
+        stats.FavorSession = bindings.TotalGainedFavorInSession;
+        stats.GatheringValueSession = bindings.TotalGatheredValueInSession;
+        stats.GatheringValueSessionPerHour = bindings.GatheringValuePerHour;
+        stats.FactionFameSession = 0;
+        stats.FameSessionPerHour = bindings.FamePerHour;
+        stats.SilverSessionPerHour = bindings.SilverPerHour;
+        stats.ReSpecSessionPerHour = bindings.ReSpecPointsPerHour;
+        stats.MightSessionPerHour = bindings.MightPerHour;
+        stats.FavorSessionPerHour = bindings.FavorPerHour;
+        stats.FactionFameSessionPerHour = 0;
+        stats.CityFaction = _mainWindowViewModel.FactionPointStats.FirstOrDefault()?.CityFaction ?? CityFaction.Unknown;
+
+        // Active time labels per period
+        var sessionStart = _trackingController.LiveStatsTracker.SessionStartUtc;
+        var sessionTs = sessionStart != default ? DateTime.Now - sessionStart.ToLocalTime() : TimeSpan.Zero;
+        stats.ActiveTimeSession = FormatActiveTime(Math.Max(0, sessionTs.TotalHours));
+        stats.ActiveTimeToday = FormatActiveTime(todayHours);
+        stats.ActiveTimeThisWeek = FormatActiveTime(thisWeekHours);
+        stats.ActiveTimeLastWeek = FormatActiveTime(lastWeekHours);
+        stats.ActiveTimeThisMonth = FormatActiveTime(thisMonthHours);
+        stats.ActiveTimeLastMonth = FormatActiveTime(lastMonthHours);
+        stats.ActiveTimeThisYear = FormatActiveTime(thisYearHours);
+        stats.ActiveTimeTotal = FormatActiveTime(totalHours);
+    }
+
+    private double SumValue(ValueType type, DateTime from, DateTime to)
+    {
+        return _dashboardStatistics.DailyValues
+            .Where(x => x.ValueType == type && x.Date >= from.Date && x.Date <= to.Date)
+            .Sum(x => x.Value);
+    }
+
+    private double SumActiveHours(DateTime from, DateTime to)
+    {
+        var seconds = _dashboardStatistics.DailyValues
+            .Where(x => x.ValueType == ValueType.ActiveTime && x.Date >= from.Date && x.Date <= to.Date)
+            .Sum(x => x.Value);
+        return seconds / 3600.0;
+    }
+
+    private static double PerHour(double value, double activeHours)
+    {
+        return activeHours > 0 ? value / activeHours : 0;
+    }
+
+    private static string FormatActiveTime(double hours)
+    {
+        var ts = TimeSpan.FromHours(hours);
+        if (ts.TotalMinutes < 1) return string.Empty;
+        if (ts.TotalHours < 1) return $"{ts.Minutes}m";
+        if (ts.TotalHours < 24) return $"{(int) ts.TotalHours}h {ts.Minutes:D2}m";
+        return $"{(int) ts.TotalDays}d {ts.Hours}h";
+    }
+
     #endregion
 
     #region Load / Save local file data
@@ -275,6 +481,7 @@ public class StatisticController
         _dashboardStatistics = await FileController.LoadAsync<DashboardStatistics>(
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, Settings.Default.UserDataDirectoryName, Settings.Default.StatsFileName));
         UpdateRepairCostsUi();
+        UpdateLifetimeStatsUi();
     }
 
     public async Task SaveInFileAsync()

--- a/src/StatisticsAnalysisTool/Styles/DashboardStyles.xaml
+++ b/src/StatisticsAnalysisTool/Styles/DashboardStyles.xaml
@@ -601,8 +601,8 @@
                 <TextBlock Text="{Binding FavorSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="1" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="1" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -635,8 +635,8 @@
                 <TextBlock Text="{Binding FavorTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="2" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="2" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -669,8 +669,8 @@
                 <TextBlock Text="{Binding FavorThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="3" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="3" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -703,8 +703,8 @@
                 <TextBlock Text="{Binding FavorLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="4" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="4" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -737,8 +737,8 @@
                 <TextBlock Text="{Binding FavorThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="5" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="5" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -771,8 +771,8 @@
                 <TextBlock Text="{Binding FavorLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="6" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="6" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -805,8 +805,8 @@
                 <TextBlock Text="{Binding FavorThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="7" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
-                <TextBlock Text="{Binding FactionFameThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionPointsThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="7" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
@@ -839,8 +839,8 @@
                 <TextBlock Text="{Binding FavorTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="8" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
-                <TextBlock Text="{Binding FactionFameTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
-                <TextBlock Text="{Binding FactionFameTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+                <TextBlock Text="{Binding FactionPointsTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding FactionPointsTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
             </StackPanel>
             <StackPanel Grid.Row="8" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
                 <TextBlock Text="{Binding GatheringValueTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>

--- a/src/StatisticsAnalysisTool/Styles/DashboardStyles.xaml
+++ b/src/StatisticsAnalysisTool/Styles/DashboardStyles.xaml
@@ -474,4 +474,379 @@
         </Grid>
     </DataTemplate>
 
+    <Style TargetType="TextBlock" x:Key="LifetimeStats.Header">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource SolidColorBrush.Text.2}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Margin" Value="4,3"/>
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="LifetimeStats.RowLabel">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+        <Setter Property="Foreground" Value="{StaticResource SolidColorBrush.Text.1}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="TextAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Margin" Value="4,0"/>
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="LifetimeStats.Value">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="Foreground" Value="{StaticResource SolidColorBrush.Text.1}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+        <Setter Property="Margin" Value="2,1"/>
+    </Style>
+
+    <Style TargetType="TextBlock" x:Key="LifetimeStats.SubValue">
+        <Setter Property="FontSize" Value="12"/>
+        <Setter Property="FontWeight" Value="Normal"/>
+        <Setter Property="Foreground" Value="{StaticResource SolidColorBrush.Text.1}"/>
+        <Setter Property="HorizontalAlignment" Value="Center"/>
+        <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <DataTemplate x:Key="LifetimeStatsTemplate" DataType="{x:Type models:LifetimeStats}">
+        <Grid Margin="4,4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="100"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+                <ColumnDefinition Width="*" MinWidth="72"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="44"/>
+                <RowDefinition Height="44"/>
+                <RowDefinition Height="44"/>
+                <RowDefinition Height="44"/>
+                <RowDefinition Height="34"/>
+                <RowDefinition Height="44"/>
+                <RowDefinition Height="34"/>
+                <RowDefinition Height="44"/>
+                <RowDefinition Height="44"/>
+            </Grid.RowDefinitions>
+
+            <!-- Row separators -->
+            <Rectangle Grid.Row="0" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#22FFFFFF"/>
+            <Rectangle Grid.Row="1" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+            <Rectangle Grid.Row="2" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+            <Rectangle Grid.Row="3" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+            <Rectangle Grid.Row="4" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+            <Rectangle Grid.Row="5" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+            <Rectangle Grid.Row="6" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+            <Rectangle Grid.Row="7" Grid.ColumnSpan="8" Height="1" VerticalAlignment="Bottom" Fill="#18FFFFFF"/>
+
+            <!-- Header row (Row 0) -->
+            <TextBlock Grid.Row="0" Grid.Column="0" Style="{StaticResource LifetimeStats.Header}" />
+            <StackPanel Grid.Row="0" Grid.Column="1" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Source="../Resources/fame.png" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationFame}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="2" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Source="../Resources/silver.png" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationSilver}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="3" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Source="../Resources/respec.png" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationReSpec}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="4" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Source="../Resources/might.png" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationMight}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="5" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Source="../Resources/favor.png" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationFavor}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="6" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Style="{StaticResource Tracker.Fraction.Coin.Icon}" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationFaction}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="0" Grid.Column="7" Orientation="Vertical" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <Image Source="../Resources/silver.png" Width="16" Height="16" Margin="0,0,0,2" HorizontalAlignment="Center"/>
+                <TextBlock Text="{Binding TranslationGatheringValue}" Style="{StaticResource LifetimeStats.Header}"/>
+            </StackPanel>
+
+            <!-- Session (Row 1) -->
+            <StackPanel Grid.Row="1" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationSession}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeSession}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="1" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueSession, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueSessionPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- Today (Row 2) -->
+            <StackPanel Grid.Row="2" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationToday}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeToday}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="2" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueToday, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueTodayPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- This Week (Row 3) -->
+            <StackPanel Grid.Row="3" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationThisWeek}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeThisWeek}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="3" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueThisWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueThisWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- Last Week (Row 4) -->
+            <StackPanel Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationLastWeek}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeLastWeek}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="4" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueLastWeek, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueLastWeekPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- This Month (Row 5) -->
+            <StackPanel Grid.Row="5" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationThisMonth}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeThisMonth}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="5" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueThisMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueThisMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- Last Month (Row 6) -->
+            <StackPanel Grid.Row="6" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationLastMonth}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeLastMonth}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="6" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueLastMonth, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueLastMonthPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- This Year (Row 7) -->
+            <StackPanel Grid.Row="7" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationThisYear}" Style="{StaticResource LifetimeStats.RowLabel}"/>
+                <TextBlock Text="{Binding ActiveTimeThisYear}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FameThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding SilverThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding ReSpecThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding MightThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FavorThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding FactionFameThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="7" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueThisYear, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}"/>
+                <TextBlock Text="{Binding GatheringValueThisYearPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+
+            <!-- Total (Row 8) -->
+            <StackPanel Grid.Row="8" Grid.Column="0" VerticalAlignment="Center">
+                <TextBlock Text="{Binding TranslationTotal}" Style="{StaticResource LifetimeStats.RowLabel}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding ActiveTimeTotal}" Style="{StaticResource LifetimeStats.SubValue}" FontWeight="SemiBold" HorizontalAlignment="Center" Margin="0,2,0,0"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="1" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FameTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding FameTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="2" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding SilverTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding SilverTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="3" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding ReSpecTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding ReSpecTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="4" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding MightTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding MightTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="5" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FavorTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding FavorTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="6" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding FactionFameTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding FactionFameTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+            <StackPanel Grid.Row="8" Grid.Column="7" HorizontalAlignment="Center" VerticalAlignment="Center">
+                <TextBlock Text="{Binding GatheringValueTotal, Converter={StaticResource ShortNumberConverter}, FallbackValue=0}" Style="{StaticResource LifetimeStats.Value}" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding GatheringValueTotalPerHour, Converter={StaticResource ShortNumberConverter}, StringFormat='{}{0}/h', FallbackValue=0/h}" Style="{StaticResource LifetimeStats.SubValue}"/>
+            </StackPanel>
+        </Grid>
+    </DataTemplate>
+
 </ResourceDictionary>

--- a/src/StatisticsAnalysisTool/UserControls/DashboardControl.xaml
+++ b/src/StatisticsAnalysisTool/UserControls/DashboardControl.xaml
@@ -108,6 +108,16 @@
                 </StackPanel>
                 <ContentControl Visibility="{Binding DashboardBindings.RepairCostsStatsVisibility}" Margin="3" 
                                 Content="{Binding DashboardBindings}" ContentTemplate="{StaticResource RepairCostsTemplate}" />
+
+                <!-- Lifetime Stats -->
+                <StackPanel Orientation="Horizontal" Height="20" Background="{StaticResource SolidColorBrush.Background.3}" MouseLeftButtonDown="LifetimeStatsToggle_OnMouseLeftButtonDown">
+                    <fa5:ImageAwesome Icon="{Binding DashboardBindings.LifetimeStatsToggleIcon, FallbackValue='Solid_Minus'}" 
+                                      Foreground="{StaticResource SolidColorBrush.Text.1}" Height="14" Width="14" Margin="10,0" VerticalAlignment="Center" />
+                    <TextBlock Text="{Binding DashboardBindings.TranslationLifetimeStats, FallbackValue='LIFETIME_STATS'}" 
+                               Foreground="{StaticResource SolidColorBrush.Accent.Blue.3}" FontSize="16" VerticalAlignment="Center" />
+                </StackPanel>
+                <ContentControl Visibility="{Binding DashboardBindings.LifetimeStatsVisibility}" Margin="3"
+                                Content="{Binding DashboardBindings.LifetimeStats}" ContentTemplate="{StaticResource LifetimeStatsTemplate}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>

--- a/src/StatisticsAnalysisTool/UserControls/DashboardControl.xaml.cs
+++ b/src/StatisticsAnalysisTool/UserControls/DashboardControl.xaml.cs
@@ -117,4 +117,19 @@ public partial class DashboardControl
             vm.DashboardBindings.RepairCostsStatsToggleIcon = EFontAwesomeIcon.Solid_Minus;
         }
     }
+
+    private void LifetimeStatsToggle_OnMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        var vm = (MainWindowViewModel) DataContext;
+        if (vm.DashboardBindings.LifetimeStatsVisibility == Visibility.Visible)
+        {
+            vm.DashboardBindings.LifetimeStatsVisibility = Visibility.Collapsed;
+            vm.DashboardBindings.LifetimeStatsToggleIcon = EFontAwesomeIcon.Solid_Plus;
+        }
+        else
+        {
+            vm.DashboardBindings.LifetimeStatsVisibility = Visibility.Visible;
+            vm.DashboardBindings.LifetimeStatsToggleIcon = EFontAwesomeIcon.Solid_Minus;
+        }
+    }
 }

--- a/src/StatisticsAnalysisTool/Views/DashboardWindow.xaml
+++ b/src/StatisticsAnalysisTool/Views/DashboardWindow.xaml
@@ -78,6 +78,10 @@
                         <Grid>
                             <ContentControl Margin="3" Content="{Binding DashboardBindings}" ContentTemplate="{StaticResource RepairCostsTemplate}" />
                         </Grid>
+                        <Separator Background="{StaticResource SolidColorBrush.Background.3}" Height="4" Margin="0,2,0,2" />
+                        <Grid>
+                            <ContentControl Margin="3" Content="{Binding DashboardBindings.LifetimeStats}" ContentTemplate="{StaticResource LifetimeStatsTemplate}" />
+                        </Grid>
                     </StackPanel>
                 </Grid>
             </ScrollViewer>


### PR DESCRIPTION
## Checklist

<!-- Put an `x` in all the boxes that apply -->

- [x] This is not a **[duplicate](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] All new and existing tests pass. 


## Changes

### New functionality

<!-- Please describe below, what new functionality was added. -->

Added a **Lifetime Stats panel** to the dashboard. It displays Fame, Silver, ReSpec, Might, Favor, Faction Fame, and Gathering Value broken down across 8 time periods: Session, Today, This Week, Last Week, This Month, Last Month, This Year, and Total. Each period shows the raw value, a per-hour rate, and the tracked active playtime for that period.

- New `LifetimeStats` model to hold all period/value combinations
- `GatheringValue` added as a tracked `ValueType`, fed from `GatheringController`
- `StatisticController` gains `UpdateLifetimeStatsUi()` which computes all periods from stored `DailyValues`, plus helpers `SumValue`, `SumActiveHours`, `PerHour`, and `FormatActiveTime`
- Active time accumulated via `AddActiveTime()` called from the existing `LiveStatsTracker` heartbeat every 2 seconds
- Panel visibility persisted via `IsLifetimeStatsVisible` in user settings
- All new labels wired to `localization.json`

### Changed functionality

<!-- Please describe below, what old functionality was changed. -->

N/A

### Removed functionality

N/A

## Additional info

<!-- Everything else you consider note-worthy that we didn't ask for. -->

The lifetime stats panel is shown by default and can be hidden via the dashboard settings toggle (`IsLifetimeStatsVisible`). Per-hour rates are calculated by dividing the value gained by the total active playtime recorded for that period (_active time is tracked while the correct character is logged in and the tool is running._)

<img width="834" height="405" alt="image" src="https://github.com/user-attachments/assets/7bcd11fa-4a7e-4e9b-8762-4f2e4f0788b9" />
