### PR TITLE
Fix capture worker crash and vault event cast failure

### DIFF
--- a/src/StatisticsAnalysisTool/Network/Events/GuildVaultInfoEvent.cs
+++ b/src/StatisticsAnalysisTool/Network/Events/GuildVaultInfoEvent.cs
@@ -8,11 +8,13 @@ namespace StatisticsAnalysisTool.Network.Events;
 
 public class GuildVaultInfoEvent
 {
+    private const int GuidByteLength = 16;
+
     public long? ObjectId;
     public string LocationGuidString;
-    public List<Guid> VaultGuidList = new();
-    public List<string> VaultNames = new();
-    public List<string> IconTags = new();
+    public List<Guid> VaultGuidList = [];
+    public List<string> VaultNames = [];
+    public List<string> IconTags = [];
 
     public GuildVaultInfoEvent(Dictionary<byte, object> parameters)
     {
@@ -28,43 +30,85 @@ public class GuildVaultInfoEvent
                 LocationGuidString = locationGuid.ToString();
             }
 
-            if (parameters.ContainsKey(2) && parameters[2] != null)
+            if (parameters.TryGetValue(2, out object vaultGuids))
             {
-                var vaultGuidArray = ((object[])parameters[2]).ToDictionary();
-
-                for (var i = 0; i < vaultGuidArray.Count; i++)
-                {
-                    var guid = vaultGuidArray[i].ObjectToGuid();
-                    if (guid != null)
-                    {
-                        VaultGuidList.Add((Guid)guid);
-                    }
-                }
+                VaultGuidList = GetVaultGuids(vaultGuids);
             }
 
-            if (parameters.ContainsKey(3) && parameters[3] != null)
+            if (parameters.TryGetValue(3, out object vaultNames))
             {
-                var vaultNameArray = ((object[])parameters[3]).ToDictionary();
-
-                for (var i = 0; i < vaultNameArray.Count; i++)
-                {
-                    VaultNames.Add(vaultNameArray[i].ToString());
-                }
+                VaultNames = GetStringValues(vaultNames);
             }
 
-            if (parameters.ContainsKey(4) && parameters[4] != null)
+            if (parameters.TryGetValue(4, out object iconTags))
             {
-                var iconTagArray = ((object[])parameters[4]).ToDictionary();
-
-                for (var i = 0; i < iconTagArray.Count; i++)
-                {
-                    IconTags.Add(iconTagArray[i].ToString());
-                }
+                IconTags = GetStringValues(iconTags);
             }
         }
         catch (Exception e)
         {
             DebugConsole.WriteError(MethodBase.GetCurrentMethod()?.DeclaringType, e);
         }
+    }
+
+    private static List<Guid> GetVaultGuids(object parameter)
+    {
+        if (parameter is byte[] vaultGuidBytes)
+        {
+            var vaultGuids = new List<Guid>();
+            var vaultCount = vaultGuidBytes.Length / GuidByteLength;
+
+            for (var i = 0; i < vaultCount; i++)
+            {
+                var guidBytes = new byte[GuidByteLength];
+                Array.Copy(vaultGuidBytes, i * GuidByteLength, guidBytes, 0, GuidByteLength);
+                vaultGuids.Add(new Guid(guidBytes));
+            }
+
+            return vaultGuids;
+        }
+
+        if (parameter is object[] vaultGuidArray)
+        {
+            var vaultGuids = new List<Guid>();
+
+            foreach (var vaultGuid in vaultGuidArray)
+            {
+                var guid = vaultGuid.ObjectToGuid();
+                if (guid != null)
+                {
+                    vaultGuids.Add(guid.Value);
+                }
+            }
+
+            return vaultGuids;
+        }
+
+        return [];
+    }
+
+    private static List<string> GetStringValues(object parameter)
+    {
+        if (parameter is string[] stringArray)
+        {
+            return new List<string>(stringArray);
+        }
+
+        if (parameter is object[] objectArray)
+        {
+            var values = new List<string>();
+            foreach (var item in objectArray)
+            {
+                values.Add(item?.ToString() ?? string.Empty);
+            }
+            return values;
+        }
+
+        if (parameter is string singleString)
+        {
+            return [singleString];
+        }
+
+        return [];
     }
 }

--- a/src/StatisticsAnalysisTool/Network/PacketProviders/LibpcapPacketProvider.cs
+++ b/src/StatisticsAnalysisTool/Network/PacketProviders/LibpcapPacketProvider.cs
@@ -318,6 +318,8 @@ public class LibpcapPacketProvider : PacketProvider
 
     private void Worker()
     {
+        const int ConsecutiveErrorsBeforeEscalation = 20;
+
         try
         {
             var dispatcher = _dispatcher;
@@ -326,12 +328,15 @@ public class LibpcapPacketProvider : PacketProvider
                 return;
             }
 
+            int consecutiveDispatchErrors = 0;
+
             while (_cts is { IsCancellationRequested: false })
             {
                 int dispatched;
                 try
                 {
                     dispatched = dispatcher.Dispatch(50);
+                    consecutiveDispatchErrors = 0;
                 }
                 catch (ObjectDisposedException)
                 {
@@ -340,6 +345,22 @@ public class LibpcapPacketProvider : PacketProvider
                 catch (InvalidOperationException)
                 {
                     break;
+                }
+                catch (PcapException ex)
+                {
+                    // A transient error on one pcap instance must not kill the whole capture
+                    // (e.g. VPN/virtual adapter flapping). Back off briefly and keep running.
+                    consecutiveDispatchErrors++;
+                    if (consecutiveDispatchErrors == ConsecutiveErrorsBeforeEscalation)
+                    {
+                        Log.Error(ex, "Libpcap: pcap_dispatch failing repeatedly ({Count}x); capture may be degraded", consecutiveDispatchErrors);
+                    }
+                    else
+                    {
+                        Log.Warning(ex, "Libpcap: pcap_dispatch failed, retrying (attempt {Count})", consecutiveDispatchErrors);
+                    }
+                    _cts?.Token.WaitHandle.WaitOne(250);
+                    continue;
                 }
 
                 if (dispatched <= 0)


### PR DESCRIPTION
## Checklist

- [x] This is not a **[duplicate](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/pulls)** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [x] All new and existing tests pass.

## Changes

### New functionality

None.

### Changed functionality

- **`LibpcapPacketProvider`** now keeps the capture worker alive across transient `PcapException`s thrown by `pcap_dispatch`. Previously, a single failure on one of the opened pcap instances (e.g. a VPN or virtual adapter going down while several devices were captured simultaneously) killed the worker thread. Capture stopped silently, and the UI kept showing the tracker as active — or partially active — while zero packets were being processed. The exception is now caught inside the dispatch loop, logged at `Warning` with a retry counter, and followed by a 250 ms back-off so a bad adapter can no longer take down the whole capture. If `pcap_dispatch` keeps failing (20 consecutive errors), one `Error` line is emitted so a genuinely broken state is still visible in the logs.

- **`GuildVaultInfoEvent`** now parses single-vault payloads. The server can serialize parameter 2 either as an `object[]` of GUIDs (multiple vaults) or as a raw `byte[]` of 16 bytes (single vault). The old code unconditionally cast to `object[]`, which threw `Unable to cast object of type 'System.Byte[]' to type 'System.Object[]'` and caused the guild vault tab to miss the event entirely. The parsing logic is now aligned with `BankVaultInfoEvent`, which already handled both shapes.

### Removed functionality

None.

## Additional info

Repro for the capture crash: run SAT as admin with several network adapters enabled (especially VPN/virtual ones such as ProtonVPN, Kaspersky VPN, WireGuard, VMware) and `NetworkDevice: -1`. Within ~20–30 minutes `pcap_dispatch` returns a generic error from one of the adapters and the worker exits. After the fix, the worker keeps running on the healthy adapter.

Repro for the vault cast: in a guild whose hideout / territory has only a single vault, opening the vault triggers the error in `sat-*.logs` and nothing is stored in `VaultController`. After the fix, `VaultGuidList` is populated with the single GUID and the vault shows up normally.