### PR TITLE
Fix UTF-8 encoding for CSV and JSON exports

### DIFF
--- a/src/StatisticsAnalysisTool/Common/ExportFileWriter.cs
+++ b/src/StatisticsAnalysisTool/Common/ExportFileWriter.cs
@@ -1,0 +1,21 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace StatisticsAnalysisTool.Common;
+
+public static class ExportFileWriter
+{
+    private static readonly Encoding Utf8WithBom =
+        new UTF8Encoding(encoderShouldEmitUTF8Identifier: true);
+
+    public static void WriteText(string fileName, string? content)
+    {
+        if (string.IsNullOrWhiteSpace(fileName))
+        {
+            throw new ArgumentException("File name must not be empty.", nameof(fileName));
+        }
+
+        File.WriteAllText(fileName, content ?? string.Empty, Utf8WithBom);
+    }
+}

--- a/src/StatisticsAnalysisTool/Guild/ManuallySiphonedEnergy.cs
+++ b/src/StatisticsAnalysisTool/Guild/ManuallySiphonedEnergy.cs
@@ -5,7 +5,6 @@ using StatisticsAnalysisTool.Localization;
 using StatisticsAnalysisTool.Network.Manager;
 using StatisticsAnalysisTool.ViewModels;
 using System;
-using System.IO;
 using System.Reflection;
 using System.Windows.Input;
 using StatisticsAnalysisTool.Diagnostics;
@@ -93,7 +92,9 @@ public class ManuallySiphonedEnergy : BaseViewModel
             try
             {
                 var trackingController = ServiceLocator.Resolve<TrackingController>();
-                File.WriteAllText(dialog.FileName, trackingController?.GuildController?.GetSiphonedEnergyListAsCsv());
+                ExportFileWriter.WriteText(
+                    dialog.FileName,
+                    trackingController?.GuildController?.GetSiphonedEnergyListAsCsv());
             }
             catch (Exception e)
             {

--- a/src/StatisticsAnalysisTool/Trade/TradeExportTemplateObject.cs
+++ b/src/StatisticsAnalysisTool/Trade/TradeExportTemplateObject.cs
@@ -3,7 +3,6 @@ using StatisticsAnalysisTool.Localization;
 using StatisticsAnalysisTool.Network.Manager;
 using System.Reflection;
 using System;
-using System.IO;
 using System.Windows.Input;
 using Microsoft.Win32;
 using Serilog;
@@ -32,7 +31,9 @@ public class TradeExportTemplateObject : BaseViewModel
             try
             {
                 var trackingController = ServiceLocator.Resolve<TrackingController>();
-                File.WriteAllText(dialog.FileName, trackingController?.TradeController?.GetTradesAsCsv());
+                ExportFileWriter.WriteText(
+                    dialog.FileName,
+                    trackingController?.TradeController?.GetTradesAsCsv());
             }
             catch (Exception e)
             {

--- a/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
+++ b/src/StatisticsAnalysisTool/ViewModels/MainWindowViewModel.cs
@@ -31,7 +31,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -554,7 +553,9 @@ public class MainWindowViewModel : BaseViewModel
             try
             {
                 var trackingController = ServiceLocator.Resolve<TrackingController>();
-                File.WriteAllText(dialog.FileName, trackingController?.LootController?.GetLootLoggerObjectsAsCsv());
+                ExportFileWriter.WriteText(
+                    dialog.FileName,
+                    trackingController?.LootController?.GetLootLoggerObjectsAsCsv());
             }
             catch (Exception e)
             {
@@ -578,7 +579,9 @@ public class MainWindowViewModel : BaseViewModel
             try
             {
                 var trackingController = ServiceLocator.Resolve<TrackingController>();
-                File.WriteAllText(dialog.FileName, trackingController?.LootController?.GetLootLoggerObjectsAsJson());
+                ExportFileWriter.WriteText(
+                    dialog.FileName,
+                    trackingController?.LootController?.GetLootLoggerObjectsAsJson());
             }
             catch (Exception e)
             {


### PR DESCRIPTION
## Checklist

- [ √ ] This is not a **[duplicate](https://github.com/Triky313/AlbionOnline-StatisticsAnalysis/pulls)** of an existing merge request.
- [ √ ] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [ √ ] All new and existing tests pass.

## Changes

### Changed functionality

- CSV and JSON exports now use explicit UTF-8 with BOM when writing files.
- This improves encoding detection in Windows tools and prevents garbled Chinese item names in exported files.

## Additional info

Resolves #625 