### PR TITLE
Complete Spanish (es-ES) localization

### DIFF
--- a/src/StatisticsAnalysisTool/Localization/localization.json
+++ b/src/StatisticsAnalysisTool/Localization/localization.json
@@ -4062,6 +4062,10 @@
         {
           "lang": "en-US",
           "seg": "Crafting costs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costos de fabricación"
         }
       ]
     },
@@ -5031,6 +5035,10 @@
           "seg": "Statistics"
         },
         {
+          "lang": "es-ES",
+          "seg": "Estadísticas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Statistiques"
         },
@@ -5056,6 +5064,10 @@
           "seg": "Trade Overview"
         },
         {
+          "lang": "es-ES",
+          "seg": "Resumen de comercio"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Aperçu des transactions"
         },
@@ -5079,6 +5091,10 @@
         {
           "lang": "en-US",
           "seg": "Diagrams"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Gráficos"
         },
         {
           "lang": "fr-FR",
@@ -13374,6 +13390,10 @@
           "seg": "Weapon"
         },
         {
+          "lang": "es-ES",
+          "seg": "Arma"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Arme"
         },
@@ -16734,6 +16754,10 @@
           "seg": "Duo"
         },
         {
+          "lang": "es-ES",
+          "seg": "Dúo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Duo"
         }
@@ -18394,6 +18418,10 @@
           "seg": "Open userData directory"
         },
         {
+          "lang": "es-ES",
+          "seg": "Abrir directorio userData"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ouvrir le répertoire UserData"
         },
@@ -18468,6 +18496,10 @@
           "seg": "Close debug console"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cerrar consola de depuración"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Fermer la console de debug"
         },
@@ -18491,6 +18523,10 @@
         {
           "lang": "en-US",
           "seg": "Debug console parameters"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Parámetros de la consola de depuración"
         },
         {
           "lang": "fr-FR",
@@ -20477,6 +20513,10 @@
           "seg": "Open extended dashboard window"
         },
         {
+          "lang": "es-ES",
+          "seg": "Abrir ventana del panel ampliado"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ouvrir la fenêtre du tableau de bord étendu"
         },
@@ -21529,6 +21569,10 @@
         {
           "lang": "en-US",
           "seg": "Export loot as JSON file"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Exportar botín como archivo JSON"
         },
         {
           "lang": "fr-FR",
@@ -23370,10 +23414,6 @@
         },
         {
           "lang": "es-ES",
-          "seg": "Buscar artículo"
-        },
-        {
-          "lang": "es-ES",
           "seg": "Buscar objeto"
         },
         {
@@ -23742,6 +23782,10 @@
         {
           "lang": "en-US",
           "seg": "Restart required"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Se requiere reiniciar"
         },
         {
           "lang": "fr-FR",
@@ -32883,6 +32927,10 @@
           "seg": "Europe Server"
         },
         {
+          "lang": "es-ES",
+          "seg": "Servidor de Europa"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Serveur Europe"
         },
@@ -33008,6 +33056,10 @@
         {
           "lang": "en-US",
           "seg": "Albion data project base url EUROPE"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "URL base de Albion Data Project para EUROPA"
         },
         {
           "lang": "fr-FR",
@@ -33233,6 +33285,10 @@
         {
           "lang": "en-US",
           "seg": "Set server"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Establecer servidor"
         },
         {
           "lang": "fr-FR",
@@ -35822,6 +35878,10 @@
           "seg": "Backup Storage Directory Path"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ruta del directorio de almacenamiento de copias de seguridad"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chemin d'accès au répertoire de stockage de sauvegarde"
         },
@@ -36027,6 +36087,10 @@
           "seg": "Can not start App with path: {path}"
         },
         {
+          "lang": "es-ES",
+          "seg": "No se puede iniciar la aplicación con la ruta: {path}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Impossible de démarrer l'application avec le chemin : {path}"
         },
@@ -36066,6 +36130,10 @@
         {
           "lang": "en-US",
           "seg": "Another app to start path"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Ruta de otra aplicación para iniciar"
         },
         {
           "lang": "fr-FR",
@@ -36109,6 +36177,10 @@
           "seg": "Cannot start other app"
         },
         {
+          "lang": "es-ES",
+          "seg": "No se puede iniciar la otra aplicación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Impossible de démarrer une autre application"
         },
@@ -36148,6 +36220,10 @@
         {
           "lang": "en-US",
           "seg": "Fishing rod"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Caña de pescar"
         },
         {
           "lang": "fr-FR",
@@ -36191,6 +36267,10 @@
           "seg": "Select Albion Online main game folder"
         },
         {
+          "lang": "es-ES",
+          "seg": "Selecciona la carpeta principal del juego Albion Online"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Sélectionnez le dossier principal du jeu Albion Online"
         },
@@ -36226,6 +36306,10 @@
         {
           "lang": "en-US",
           "seg": "Please select a correct Albion Online main game folder"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Selecciona una carpeta principal válida de Albion Online"
         },
         {
           "lang": "fr-FR",
@@ -36265,6 +36349,10 @@
           "seg": "Please select a correct folder"
         },
         {
+          "lang": "es-ES",
+          "seg": "Selecciona una carpeta válida"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Veuillez sélectionner un dossier correct"
         },
@@ -36300,6 +36388,10 @@
         {
           "lang": "en-US",
           "seg": "Select main game folder..."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Seleccionar carpeta principal del juego..."
         },
         {
           "lang": "fr-FR",
@@ -36339,6 +36431,10 @@
           "seg": "Game folder path"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ruta de la carpeta del juego"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Game folder path"
         },
@@ -36374,6 +36470,10 @@
         {
           "lang": "en-US",
           "seg": "Confirm"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Confirmar"
         },
         {
           "lang": "fr-FR",
@@ -36413,6 +36513,10 @@
           "seg": "Overhealed percentage of total healing"
         },
         {
+          "lang": "es-ES",
+          "seg": "Porcentaje de sobrecuración respecto a la curación total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Pourcentage de soin excessif par rapport au soin totale"
         },
@@ -36450,6 +36554,10 @@
           "seg": "Healing without overhealed"
         },
         {
+          "lang": "es-ES",
+          "seg": "Curación sin sobrecuración"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Soin sans soin excessif"
         },
@@ -36485,6 +36593,10 @@
         {
           "lang": "en-US",
           "seg": "Knightfall Abbey"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Abadía de Knightfall"
         },
         {
           "lang": "fr-FR",
@@ -36528,6 +36640,10 @@
           "seg": "Loading"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cargando"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chargement"
         },
@@ -36563,6 +36679,10 @@
         {
           "lang": "en-US",
           "seg": "Net profit"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio neto"
         },
         {
           "lang": "fr-FR",
@@ -36606,6 +36726,10 @@
           "seg": "Year"
         },
         {
+          "lang": "es-ES",
+          "seg": "Año"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Année"
         },
@@ -36647,6 +36771,10 @@
           "seg": "Checkpoint"
         },
         {
+          "lang": "es-ES",
+          "seg": "Punto de control"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Checkpoint"
         },
@@ -36682,6 +36810,10 @@
         {
           "lang": "en-US",
           "seg": "Most valuable loot"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Botín más valioso"
         },
         {
           "lang": "fr-FR",
@@ -36725,6 +36857,10 @@
           "seg": "Cluster Type"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tipo de zona"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Type de cluster"
         },
@@ -36760,6 +36896,10 @@
         {
           "lang": "en-US",
           "seg": "Locked chest"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cofre bloqueado"
         },
         {
           "lang": "fr-FR",
@@ -36799,6 +36939,10 @@
           "seg": "Run time"
         },
         {
+          "lang": "es-ES",
+          "seg": "Duración"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Durée"
         },
@@ -36834,6 +36978,10 @@
         {
           "lang": "en-US",
           "seg": "Avg."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Prom."
         },
         {
           "lang": "fr-FR",
@@ -36877,6 +37025,10 @@
           "seg": "hr"
         },
         {
+          "lang": "es-ES",
+          "seg": "h"
+        },
+        {
           "lang": "fr-FR",
           "seg": "h"
         },
@@ -36916,6 +37068,10 @@
         {
           "lang": "en-US",
           "seg": "Average"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Promedio"
         },
         {
           "lang": "fr-FR",
@@ -36959,6 +37115,10 @@
           "seg": "Per hour"
         },
         {
+          "lang": "es-ES",
+          "seg": "Por hora"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Par heure"
         },
@@ -36998,6 +37158,10 @@
         {
           "lang": "en-US",
           "seg": "Type"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tipo"
         },
         {
           "lang": "fr-FR",
@@ -37041,6 +37205,10 @@
           "seg": "HCE (Expedition)"
         },
         {
+          "lang": "es-ES",
+          "seg": "HCE (Expedición)"
+        },
+        {
           "lang": "fr-FR",
           "seg": "HCE (Expédition)"
         },
@@ -37082,6 +37250,10 @@
           "seg": "Number of dungeons"
         },
         {
+          "lang": "es-ES",
+          "seg": "Número de mazmorras"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nombre de donjons"
         },
@@ -37117,6 +37289,10 @@
         {
           "lang": "en-US",
           "seg": "Fights"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Combates"
         },
         {
           "lang": "fr-FR",
@@ -37156,6 +37332,10 @@
           "seg": "Shapeshifter"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cambiaformas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Changeforme"
         },
@@ -37193,6 +37373,10 @@
           "seg": "Tracking tool"
         },
         {
+          "lang": "es-ES",
+          "seg": "Herramienta de seguimiento"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Outil de pistage"
         },
@@ -37228,6 +37412,10 @@
         {
           "lang": "en-US",
           "seg": "Total Overview"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Resumen total"
         },
         {
           "lang": "fr-FR",
@@ -37271,6 +37459,10 @@
           "seg": "Last month"
         },
         {
+          "lang": "es-ES",
+          "seg": "Último mes"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Le mois dernier"
         },
@@ -37306,6 +37498,10 @@
         {
           "lang": "en-US",
           "seg": "Select server location"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Seleccionar ubicación del servidor"
         },
         {
           "lang": "fr-FR",
@@ -37345,6 +37541,10 @@
           "seg": "Please select a server location"
         },
         {
+          "lang": "es-ES",
+          "seg": "Selecciona una ubicación del servidor"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Veuillez sélectionner un emplacement de serveur"
         },
@@ -37380,6 +37580,10 @@
         {
           "lang": "en-US",
           "seg": "Kills / Deaths"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Asesinatos / Muertes"
         },
         {
           "lang": "fr-FR",
@@ -37423,6 +37627,10 @@
           "seg": "Kills / Deaths (Loading)"
         },
         {
+          "lang": "es-ES",
+          "seg": "Asesinatos / Muertes (Cargando)"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Tués / Morts (Chargement)"
         },
@@ -37464,6 +37672,10 @@
           "seg": "Repair costs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Costos de reparación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coût de réparation"
         },
@@ -37501,6 +37713,10 @@
           "seg": "1. first select the 3rd tab on the right side."
         },
         {
+          "lang": "es-ES",
+          "seg": "1. primero selecciona la tercera pestaña del lado derecho."
+        },
+        {
           "lang": "fr-FR",
           "seg": "1. Sélectionnez d’abord le 3ème onglet sur le côté droit."
         },
@@ -37532,6 +37748,10 @@
         {
           "lang": "en-US",
           "seg": "2. select siphoned energy in search"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "2. busca y selecciona energía drenada."
         },
         {
           "lang": "fr-FR",
@@ -37567,6 +37787,10 @@
           "seg": "3. choose a time to track more or less entries"
         },
         {
+          "lang": "es-ES",
+          "seg": "3. elige un intervalo de tiempo para rastrear más o menos entradas."
+        },
+        {
           "lang": "fr-FR",
           "seg": "3. Choisissez une heure pour suivre les entrées"
         },
@@ -37598,6 +37822,10 @@
         {
           "lang": "en-US",
           "seg": "4. each page must be called individually so that it can be tracked."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "4. cada página debe abrirse individualmente para poder rastrearla."
         },
         {
           "lang": "fr-FR",
@@ -37633,6 +37861,10 @@
           "seg": "Guild"
         },
         {
+          "lang": "es-ES",
+          "seg": "Gremio"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Guilde"
         },
@@ -37664,6 +37896,10 @@
         {
           "lang": "en-US",
           "seg": "Delete selected entries"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Eliminar entradas seleccionadas"
         },
         {
           "lang": "fr-FR",
@@ -37699,6 +37935,10 @@
           "seg": "Sure you want to delete selected entries?"
         },
         {
+          "lang": "es-ES",
+          "seg": "¿Seguro que quieres eliminar las entradas seleccionadas?"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Êtes-vous sûr de vouloir supprimer les entrées sélectionnées ?"
         },
@@ -37730,6 +37970,10 @@
         {
           "lang": "en-US",
           "seg": "Character name"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Nombre del personaje"
         },
         {
           "lang": "fr-FR",
@@ -37765,6 +38009,10 @@
           "seg": "Quantity"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cantidad"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Quantité"
         },
@@ -37796,6 +38044,10 @@
         {
           "lang": "en-US",
           "seg": "Add entry"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Añadir entrada"
         },
         {
           "lang": "fr-FR",
@@ -37831,6 +38083,10 @@
           "seg": "Add or remove manually"
         },
         {
+          "lang": "es-ES",
+          "seg": "Añadir o eliminar manualmente"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ajouter ou supprimer manuellement"
         },
@@ -37862,6 +38118,10 @@
         {
           "lang": "en-US",
           "seg": "Select to disable"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Seleccionar para desactivar"
         },
         {
           "lang": "fr-FR",
@@ -37897,6 +38157,10 @@
           "seg": "Siphoned energy"
         },
         {
+          "lang": "es-ES",
+          "seg": "Energía drenada"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Énergie siphonnée"
         },
@@ -37928,6 +38192,10 @@
         {
           "lang": "en-US",
           "seg": "Packet provider"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Proveedor de paquetes"
         },
         {
           "lang": "fr-FR",
@@ -37963,6 +38231,10 @@
           "seg": "Network adapters"
         },
         {
+          "lang": "es-ES",
+          "seg": "Adaptadores de red"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Interfaces réseau"
         },
@@ -37988,6 +38260,10 @@
           "seg": "Restart network tracking"
         },
         {
+          "lang": "es-ES",
+          "seg": "Reiniciar seguimiento de red"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Redémarrer le suivi du réseau"
         },
@@ -38011,6 +38287,10 @@
         {
           "lang": "en-US",
           "seg": "Tool must be run as admin"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "La herramienta debe ejecutarse como administrador"
         },
         {
           "lang": "fr-FR",
@@ -38046,6 +38326,10 @@
           "seg": "Added crafting"
         },
         {
+          "lang": "es-ES",
+          "seg": "Fabricación añadida"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ajout d'une fabrication"
         },
@@ -38079,6 +38363,10 @@
           "seg": "Party"
         },
         {
+          "lang": "es-ES",
+          "seg": "Grupo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Groupe"
         },
@@ -38102,6 +38390,10 @@
         {
           "lang": "en-US",
           "seg": "Death Alert"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Alerta de muerte"
         },
         {
           "lang": "fr-FR",
@@ -38129,6 +38421,10 @@
           "seg": "Select for death alert"
         },
         {
+          "lang": "es-ES",
+          "seg": "Seleccionar para alerta de muerte"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Sélectionnez pour l'alerte de mort"
         },
@@ -38152,6 +38448,10 @@
         {
           "lang": "en-US",
           "seg": "Death alert sound used"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Sonido usado para la alerta de muerte"
         },
         {
           "lang": "fr-FR",
@@ -38179,6 +38479,10 @@
           "seg": "DMG%"
         },
         {
+          "lang": "es-ES",
+          "seg": "DAÑO%"
+        },
+        {
           "lang": "fr-FR",
           "seg": "DÉGATS%"
         },
@@ -38204,6 +38508,10 @@
           "seg": "DMG/HEAL"
         },
         {
+          "lang": "es-ES",
+          "seg": "DAÑO/CURACIÓN"
+        },
+        {
           "lang": "fr-FR",
           "seg": "DÉGATS/SOINS"
         },
@@ -38226,6 +38534,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "Ticks"
+        },
+        {
+          "lang": "es-ES",
           "seg": "Ticks"
         },
         {
@@ -38254,6 +38566,10 @@
           "seg": "Auto attack"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ataque automático"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Attaque automatique"
         },
@@ -38277,6 +38593,10 @@
         {
           "lang": "en-US",
           "seg": "Export trades as CSV"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Exportar intercambios como CSV"
         },
         {
           "lang": "fr-FR",
@@ -38304,6 +38624,10 @@
           "seg": "Event validation"
         },
         {
+          "lang": "es-ES",
+          "seg": "Validación de eventos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Validation d'événement"
         },
@@ -38327,6 +38651,10 @@
         {
           "lang": "en-US",
           "seg": "Open event validation"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Abrir validación de eventos"
         },
         {
           "lang": "fr-FR",
@@ -38354,6 +38682,10 @@
           "seg": "Damage suffered"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño recibido"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dégâts subis"
         },
@@ -38377,6 +38709,10 @@
         {
           "lang": "en-US",
           "seg": "Average est. Market value"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Valor de mercado estimado promedio"
         },
         {
           "lang": "fr-FR",
@@ -38404,6 +38740,10 @@
           "seg": "Standalone Launcher"
         },
         {
+          "lang": "es-ES",
+          "seg": "Launcher independiente"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Application indépendante"
         },
@@ -38427,6 +38767,10 @@
         {
           "lang": "en-US",
           "seg": "Select the AlbionOnline folder where you installed it. For example, under 'C:\\AlbionOnline'"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Selecciona la carpeta AlbionOnline donde lo instalaste. Por ejemplo, en 'C:\\AlbionOnline'"
         },
         {
           "lang": "fr-FR",
@@ -38454,6 +38798,10 @@
           "seg": "Steam Launcher"
         },
         {
+          "lang": "es-ES",
+          "seg": "Launcher de Steam"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Launcher Steam"
         },
@@ -38477,6 +38825,10 @@
         {
           "lang": "en-US",
           "seg": "Select the AlbionOnline folder in the steamapps. Usually found under 'C:\\Program Files\\Steam\\steamapps\\common'"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Selecciona la carpeta AlbionOnline dentro de steamapps. Normalmente se encuentra en 'C:\\Program Files\\Steam\\steamapps\\common'"
         },
         {
           "lang": "fr-FR",
@@ -38504,6 +38856,10 @@
           "seg": "Backup storage directory path"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ruta del directorio de almacenamiento de copias de seguridad"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Répertoire de stockage de sauvegarde"
         },
@@ -38527,6 +38883,10 @@
         {
           "lang": "en-US",
           "seg": "Current repair costs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costos de reparación actuales"
         },
         {
           "lang": "fr-FR",
@@ -38554,6 +38914,10 @@
           "seg": "Show total avg prices on Item"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mostrar precios promedio totales en el objeto"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Afficher les prix moyens totaux de l'objet"
         },
@@ -38577,6 +38941,10 @@
         {
           "lang": "en-US",
           "seg": "Total chest value"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Valor total del cofre"
         },
         {
           "lang": "fr-FR",
@@ -38604,6 +38972,10 @@
           "seg": "Total weight"
         },
         {
+          "lang": "es-ES",
+          "seg": "Peso total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Poids total"
         },
@@ -38627,6 +38999,10 @@
         {
           "lang": "en-US",
           "seg": "Total bank value"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Valor total del banco"
         },
         {
           "lang": "fr-FR",
@@ -38654,6 +39030,10 @@
           "seg": "Others"
         },
         {
+          "lang": "es-ES",
+          "seg": "Otros"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Autres"
         },
@@ -38677,6 +39057,10 @@
         {
           "lang": "en-US",
           "seg": "Lost"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Perdido"
         },
         {
           "lang": "fr-FR",
@@ -38704,6 +39088,10 @@
           "seg": "Resolved"
         },
         {
+          "lang": "es-ES",
+          "seg": "Resuelto"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Résolu"
         },
@@ -38727,6 +39115,10 @@
         {
           "lang": "en-US",
           "seg": "Donated"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Donado"
         },
         {
           "lang": "fr-FR",
@@ -38754,6 +39146,10 @@
           "seg": "Loot comparator"
         },
         {
+          "lang": "es-ES",
+          "seg": "Comparador de botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Comparateur de butin"
         },
@@ -38777,6 +39173,10 @@
         {
           "lang": "en-US",
           "seg": "Upload chest files"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Subir archivos de cofre"
         },
         {
           "lang": "fr-FR",
@@ -38804,6 +39204,10 @@
           "seg": "Add chest logs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Añadir registros de cofre"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ajouter des Chest Logs"
         },
@@ -38826,6 +39230,10 @@
         {
           "lang": "en-US",
           "seg": "Paste chest log here"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Pega aquí el registro del cofre"
         },
         {
           "lang": "fr-FR",
@@ -38853,6 +39261,10 @@
           "seg": "{CHEST_COUNT} chest files | {LOOT_COUNT} loot log files"
         },
         {
+          "lang": "es-ES",
+          "seg": "{CHEST_COUNT} archivos de cofre | {LOOT_COUNT} archivos de registro de botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{CHEST_COUNT} fichiers Chest | {LOOT_COUNT} fichiers Loot-log"
         },
@@ -38876,6 +39288,10 @@
         {
           "lang": "en-US",
           "seg": "Counts loaded chest log files plus valid chest text imports and loot log files that added at least one loot entry."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cuenta los archivos de registro de cofre cargados, las importaciones válidas de texto de cofres y los archivos de registro de botín que añadieron al menos una entrada de botín."
         },
         {
           "lang": "fr-FR",
@@ -38903,6 +39319,10 @@
           "seg": "Invalid Chest-Log file skipped: {FILE_NAME}"
         },
         {
+          "lang": "es-ES",
+          "seg": "Se omitió un archivo de registro de cofre no válido: {FILE_NAME}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Fichier de Chest-Log non valide ignoré: {FILE_NAME}"
         },
@@ -38926,6 +39346,10 @@
         {
           "lang": "en-US",
           "seg": "Invalid chest log text was not loaded."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No se cargó el texto del registro de cofre porque no es válido."
         },
         {
           "lang": "fr-FR",
@@ -38953,6 +39377,10 @@
           "seg": "Invalid loot log file skipped: {FILE_NAME}"
         },
         {
+          "lang": "es-ES",
+          "seg": "Se omitió un archivo de registro de botín no válido: {FILE_NAME}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Le fichier Loot-Log non valide ignoré: {FILE_NAME}"
         },
@@ -38976,6 +39404,10 @@
         {
           "lang": "en-US",
           "seg": "Add loot log files"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Añadir archivos de registro de botín"
         },
         {
           "lang": "fr-FR",
@@ -39003,6 +39435,10 @@
           "seg": "Select chest log files"
         },
         {
+          "lang": "es-ES",
+          "seg": "Seleccionar archivos de registro de cofre"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Sélectionner les fichiers journaux de coffre"
         },
@@ -39026,6 +39462,10 @@
         {
           "lang": "en-US",
           "seg": "Select loot log files"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Seleccionar archivos de registro de botín"
         },
         {
           "lang": "fr-FR",
@@ -39053,6 +39493,10 @@
           "seg": "Status"
         },
         {
+          "lang": "es-ES",
+          "seg": "Estado"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Statut"
         },
@@ -39076,6 +39520,10 @@
         {
           "lang": "en-US",
           "seg": "Tier"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Nivel"
         },
         {
           "lang": "fr-FR",
@@ -39103,6 +39551,10 @@
           "seg": "Type"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tipo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Type"
         },
@@ -39126,6 +39578,10 @@
         {
           "lang": "en-US",
           "seg": "All"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Todos"
         },
         {
           "lang": "fr-FR",
@@ -39153,6 +39609,10 @@
           "seg": "None"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ninguno"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Aucun"
         },
@@ -39176,6 +39636,10 @@
         {
           "lang": "en-US",
           "seg": "{COUNT} selected"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "{COUNT} seleccionados"
         },
         {
           "lang": "fr-FR",
@@ -39203,6 +39667,10 @@
           "seg": "Compare logs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Comparar registros"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Comparer les logs"
         },
@@ -39226,6 +39694,10 @@
         {
           "lang": "en-US",
           "seg": "Delete chest logs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Eliminar registros de cofre"
         },
         {
           "lang": "fr-FR",
@@ -39253,6 +39725,10 @@
           "seg": "Delete all logs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Eliminar todos los registros"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Supprimer tous les logs"
         },
@@ -39277,6 +39753,10 @@
           "lang": "en-US",
           "seg": "Save comparator state"
         },
+        {
+          "lang": "es-ES",
+          "seg": "Guardar estado del comparador"
+        },
 		{
           "lang": "fr-FR",
           "seg": "Enregistrer l'état du comparateur"
@@ -39293,6 +39773,10 @@
         {
           "lang": "en-US",
           "seg": "Load comparator state"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cargar estado del comparador"
         },
         {
           "lang": "fr-FR",
@@ -39312,6 +39796,10 @@
           "seg": "Name for the comparator state:"
         },
         {
+          "lang": "es-ES",
+          "seg": "Nombre para el estado del comparador:"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nom de l'état de référence :"
         }
@@ -39327,6 +39815,10 @@
         {
           "lang": "en-US",
           "seg": "The currently loaded logs will be removed. Do you want to load the selected state?"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Los registros cargados actualmente se eliminarán. ¿Quieres cargar el estado seleccionado?"
         },
         {
           "lang": "fr-FR",
@@ -39346,6 +39838,10 @@
           "seg": "The comparator state could not be saved."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudo guardar el estado del comparador."
+        },
+        {
           "lang": "fr-FR",
           "seg": "L'état du comparateur n'a pas pu être enregistré."
         }
@@ -39361,6 +39857,10 @@
         {
           "lang": "en-US",
           "seg": "The comparator state could not be loaded. The saved files may be corrupted."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No se pudo cargar el estado del comparador. Es posible que los archivos guardados estén dañados."
         },
         {
           "lang": "fr-FR",
@@ -39380,6 +39880,10 @@
           "seg": "Save"
         },
         {
+          "lang": "es-ES",
+          "seg": "Guardar"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Enregistrer"
         }
@@ -39395,6 +39899,10 @@
         {
           "lang": "en-US",
           "seg": "Cancel"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cancelar"
         },
         {
           "lang": "fr-FR",
@@ -39414,6 +39922,10 @@
           "seg": "Delete selected comparator state"
         },
         {
+          "lang": "es-ES",
+          "seg": "Eliminar estado seleccionado del comparador"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Supprimer l'état du comparateur sélectionné"
         }
@@ -39429,6 +39941,10 @@
         {
           "lang": "en-US",
           "seg": "Do you really want to delete the comparator state \"{SAVE_NAME}\"? This action cannot be undone."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "¿Realmente quieres eliminar el estado del comparador \"{SAVE_NAME}\"? Esta acción no se puede deshacer."
         },
         {
           "lang": "fr-FR",
@@ -39448,6 +39964,10 @@
           "seg": "The comparator state could not be deleted."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudo eliminar el estado del comparador."
+        },
+        {
           "lang": "fr-FR",
           "seg": "L'état de comparaison n'a pas pu être supprimé."
         }
@@ -39463,6 +39983,10 @@
         {
           "lang": "en-US",
           "seg": "Filters"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Filtros"
         },
         {
           "lang": "fr-FR",
@@ -39482,6 +40006,10 @@
           "seg": "Chest log input"
         },
         {
+          "lang": "es-ES",
+          "seg": "Entrada de registro de cofre"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Saisie dans le journal de bord"
         }
@@ -39497,6 +40025,10 @@
         {
           "lang": "en-US",
           "seg": "Comparison"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Comparación"
         },
         {
           "lang": "fr-FR",
@@ -39516,6 +40048,10 @@
           "seg": "Actions"
         },
         {
+          "lang": "es-ES",
+          "seg": "Acciones"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Action"
         }
@@ -39533,6 +40069,10 @@
           "seg": "Saved comparator:"
         },
         {
+          "lang": "es-ES",
+          "seg": "Comparador guardado:"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Comparateur enregistré"
         }
@@ -39548,6 +40088,10 @@
         {
           "lang": "en-US",
           "seg": "Remove player from loot comparator"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Eliminar jugador del comparador de botín"
         },
         {
           "lang": "fr-FR",
@@ -39575,6 +40119,10 @@
           "seg": "Copy this player's loot logs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Copiar los registros de botín de este jugador"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Copier les journaux de butin de ce joueur"
         },
@@ -39598,6 +40146,10 @@
         {
           "lang": "en-US",
           "seg": "Gray"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Gris"
         },
         {
           "lang": "fr-FR",
@@ -39625,6 +40177,10 @@
           "seg": "Green"
         },
         {
+          "lang": "es-ES",
+          "seg": "Verde"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Vert"
         },
@@ -39648,6 +40204,10 @@
         {
           "lang": "en-US",
           "seg": "Blue"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Azul"
         },
         {
           "lang": "fr-FR",
@@ -39675,6 +40235,10 @@
           "seg": "Red"
         },
         {
+          "lang": "es-ES",
+          "seg": "Rojo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Rouge"
         },
@@ -39700,6 +40264,10 @@
           "seg": "T1 - T3"
         },
         {
+          "lang": "es-ES",
+          "seg": "T1 - T3"
+        },
+        {
           "lang": "fr-FR",
           "seg": "T1 - T3"
         },
@@ -39722,6 +40290,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "Proxy"
+        },
+        {
+          "lang": "es-ES",
           "seg": "Proxy"
         },
         {
@@ -39754,6 +40326,10 @@
           "seg": "Change requires a tool restart"
         },
         {
+          "lang": "es-ES",
+          "seg": "El cambio requiere reiniciar la herramienta"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Le changement nécessite un redémarrage de l'application"
         },
@@ -39777,6 +40353,10 @@
         {
           "lang": "en-US",
           "seg": "Direct purchase and sale data is encrypted and cannot currently be viewed with this character."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Los datos de compra y venta directa están cifrados y actualmente no se pueden ver con este personaje."
         },
         {
           "lang": "fr-FR",
@@ -39804,6 +40384,10 @@
           "seg": "Total distance fee"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tarifa total por distancia"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Total des frais de trajet"
         },
@@ -39827,6 +40411,10 @@
         {
           "lang": "en-US",
           "seg": "Total income without tax deductions"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Ingresos totales sin deducir impuestos"
         },
         {
           "lang": "fr-FR",
@@ -39854,6 +40442,10 @@
           "seg": "Only damage to players counts"
         },
         {
+          "lang": "es-ES",
+          "seg": "Solo cuenta el daño a jugadores"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Seuls les dégâts infligés aux joueurs comptent"
         },
@@ -39877,6 +40469,10 @@
         {
           "lang": "en-US",
           "seg": "Total cost without added taxes"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costo total sin impuestos añadidos"
         },
         {
           "lang": "fr-FR",
@@ -40034,6 +40630,10 @@
           "seg": "Operator"
         },
         {
+          "lang": "es-ES",
+          "seg": "Operador"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Opérateur"
         },
@@ -40057,6 +40657,10 @@
         {
           "lang": "en-US",
           "seg": "Deposit"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Depositar"
         },
         {
           "lang": "fr-FR",
@@ -40084,6 +40688,10 @@
           "seg": "Withdraw"
         },
         {
+          "lang": "es-ES",
+          "seg": "Retirar"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Retirer"
         },
@@ -40107,6 +40715,10 @@
         {
           "lang": "en-US",
           "seg": "Export as CSV"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Exportar como CSV"
         },
         {
           "lang": "fr-FR",
@@ -40134,6 +40746,10 @@
           "seg": "Export Siphoned Energy list"
         },
         {
+          "lang": "es-ES",
+          "seg": "Exportar lista de energía drenada"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Liste des exportations d'énergie siphonnée"
         },
@@ -40157,6 +40773,10 @@
         {
           "lang": "en-US",
           "seg": "How do I get the chest logs?"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "¿Cómo obtengo los registros de cofre?"
         },
         {
           "lang": "fr-FR",
@@ -40184,6 +40804,10 @@
           "seg": "Follow these steps to obtain the chest logs from the game:"
         },
         {
+          "lang": "es-ES",
+          "seg": "Sigue estos pasos para obtener los registros de cofre del juego:"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Suivez ces étapes pour obtenir les journaux de coffre du jeu :"
         },
@@ -40207,6 +40831,10 @@
         {
           "lang": "en-US",
           "seg": "1. Click \"Actions\" in your guild bank."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "1. Haz clic en \"Acciones\" en el banco de tu gremio."
         },
         {
           "lang": "fr-FR",
@@ -40234,6 +40862,10 @@
           "seg": "2. Click \"Manage\"."
         },
         {
+          "lang": "es-ES",
+          "seg": "2. Haz clic en \"Administrar\"."
+        },
+        {
           "lang": "fr-FR",
           "seg": "2. Cliquez sur \"Manage\"."
         },
@@ -40257,6 +40889,10 @@
         {
           "lang": "en-US",
           "seg": "3. Open \"Chest Log\"."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "3. Abre \"Registro del cofre\"."
         },
         {
           "lang": "fr-FR",
@@ -40284,6 +40920,10 @@
           "seg": "4. Click \"Copy to clipboard\"."
         },
         {
+          "lang": "es-ES",
+          "seg": "4. Haz clic en \"Copiar al portapapeles\"."
+        },
+        {
           "lang": "fr-FR",
           "seg": "4. Cliquez sur \"Copy to clipboard\"."
         },
@@ -40307,6 +40947,10 @@
         {
           "lang": "en-US",
           "seg": "Paste the copied chest log directly into the \"Chest log input\" field and click \"Add chest logs\"."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Pega el registro del cofre copiado directamente en el campo \"Entrada de registro de cofre\" y haz clic en \"Añadir registros de cofre\"."
         },
         {
           "lang": "fr-FR",
@@ -40334,6 +40978,10 @@
           "seg": "Alternatively, use \"Upload chest files\" to select one or more .csv files. Chest logs with tab-separated columns, as copied from the clipboard, and comma-separated CSV files are supported. Other file formats are not supported."
         },
         {
+          "lang": "es-ES",
+          "seg": "Como alternativa, usa \"Subir archivos de cofre\" para seleccionar uno o más archivos .csv. Se admiten registros de cofre con columnas separadas por tabulaciones, tal como se copian desde el portapapeles, y archivos CSV separados por comas. No se admiten otros formatos de archivo."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Vous pouvez également sélectionner un ou plusieurs fichiers .csv à l'aide du bouton \"Télécharger les données\". Les journaux de coffre avec des colonnes séparées par des tabulations, tels qu'ils sont copiés depuis le presse-papiers, ainsi que les fichiers CSV séparés par des virgules sont pris en charge. Les autres formats de fichier ne sont pas pris en charge."
         },
@@ -40357,6 +41005,10 @@
         {
           "lang": "en-US",
           "seg": "Loot log files"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Archivos de registro de botín"
         },
         {
           "lang": "fr-FR",
@@ -40384,6 +41036,10 @@
           "seg": "Export loot logs from the Logging tab using the green CSV button. In the Loot Comparator, use \"Add loot log files\" to load one or more of these .csv files. Semicolon-separated loot log CSV files with the expected header are supported; JSON and other file formats are not supported. Then click \"Compare logs\"."
         },
         {
+          "lang": "es-ES",
+          "seg": "Exporta los registros de botín desde la pestaña Registro usando el botón CSV verde. En el Comparador de botín, usa \"Añadir archivos de registro de botín\" para cargar uno o más de estos archivos .csv. Se admiten archivos CSV de registro de botín separados por punto y coma con el encabezado esperado; no se admiten JSON ni otros formatos. Luego haz clic en \"Comparar registros\"."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Exportez les journaux de butin depuis l'onglet de journalisation à l'aide du bouton CSV vert. Dans le comparateur de butin, utilisez le bouton d'ajout des fichiers journaux de butin pour charger un ou plusieurs de ces fichiers .csv. Les fichiers CSV séparés par des points-virgules et contenant l'en-tête attendu sont pris en charge ; les fichiers JSON et les autres formats ne le sont pas. Cliquez ensuite sur le bouton permettant de comparer les journaux."
         },
@@ -40407,6 +41063,10 @@
         {
           "lang": "en-US",
           "seg": "What do the item slot colors mean?"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "¿Qué significan los colores de las casillas de los objetos?"
         },
         {
           "lang": "fr-FR",
@@ -40434,6 +41094,10 @@
           "seg": "Grey items were either detected as lost or come from a chest entry that could not be matched reliably to an earlier loot entry. Lost means that another player later picked up the same item from the original looter."
         },
         {
+          "lang": "es-ES",
+          "seg": "Los objetos grises se detectaron como perdidos o provienen de una entrada de cofre que no pudo vincularse de forma fiable con una entrada de botín anterior. Perdido significa que otro jugador recogió después el mismo objeto del saqueador original."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Les objets gris ont été détectés comme perdus ou proviennent d'une entrée de coffre qui n'a pas pu être associée de manière fiable à une entrée de butin antérieure. Perdu signifie qu'un autre joueur a récupéré plus tard le même objet sur le premier récupérateur."
         },
@@ -40457,6 +41121,10 @@
         {
           "lang": "en-US",
           "seg": "Green items are loot entries matched to a later chest entry from the same player with the same item and quantity."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Los objetos verdes son entradas de botín que coinciden con una entrada posterior de cofre del mismo jugador, con el mismo objeto y cantidad."
         },
         {
           "lang": "fr-FR",
@@ -40484,6 +41152,10 @@
           "seg": "Blue items are positive chest entries for which no matching earlier loot entry was found and which the tool therefore classifies as donations based on the event order."
         },
         {
+          "lang": "es-ES",
+          "seg": "Los objetos azules son entradas positivas de cofre para las que no se encontró una entrada de botín anterior coincidente y que, por tanto, la herramienta clasifica como donaciones según el orden de los eventos."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Les objets bleus sont des entrées positives de coffre pour lesquelles aucune entrée de butin antérieure correspondante n'a été trouvée et que l'outil classe donc comme des dons selon l'ordre des événements."
         },
@@ -40507,6 +41179,10 @@
         {
           "lang": "en-US",
           "seg": "Red items are unresolved loot entries. No matching later chest entry or later loss was found. The color does not prove that the player still owns the item."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Los objetos rojos son entradas de botín sin resolver. No se encontró una entrada de cofre posterior coincidente ni una pérdida posterior. El color no demuestra que el jugador aún conserve el objeto."
         },
         {
           "lang": "fr-FR",
@@ -40534,6 +41210,10 @@
           "seg": "Data saved"
         },
         {
+          "lang": "es-ES",
+          "seg": "Datos guardados"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Données enregistrées"
         },
@@ -40557,6 +41237,10 @@
         {
           "lang": "en-US",
           "seg": "All tool data has been saved."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Se han guardado todos los datos de la herramienta."
         },
         {
           "lang": "fr-FR",
@@ -40584,6 +41268,10 @@
           "seg": "Profit analysis"
         },
         {
+          "lang": "es-ES",
+          "seg": "Análisis de beneficios"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Analyse des bénéfices"
         },
@@ -40607,6 +41295,10 @@
         {
           "lang": "en-US",
           "seg": "Break even price"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Precio de equilibrio"
         },
         {
           "lang": "fr-FR",
@@ -40634,6 +41326,10 @@
           "seg": "Return on invenstment"
         },
         {
+          "lang": "es-ES",
+          "seg": "Retorno de la inversión"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Retour sur investissement"
         },
@@ -40657,6 +41353,10 @@
         {
           "lang": "en-US",
           "seg": "Profit per item"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio por objeto"
         },
         {
           "lang": "fr-FR",
@@ -40684,6 +41384,10 @@
           "seg": "Profit relative to investment."
         },
         {
+          "lang": "es-ES",
+          "seg": "Beneficio en relación con la inversión."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Bénéfice par rapport à l'investissement."
         },
@@ -40707,6 +41411,10 @@
         {
           "lang": "en-US",
           "seg": "Profit per item sold."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio por objeto vendido."
         },
         {
           "lang": "fr-FR",
@@ -40734,6 +41442,10 @@
           "seg": "Price without loss or profit."
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio sin pérdida ni beneficio."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix sans perte ni gain."
         },
@@ -40757,6 +41469,10 @@
         {
           "lang": "en-US",
           "seg": "Open debug console when starting the tool"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Abrir la consola de depuración al iniciar la herramienta"
         },
         {
           "lang": "fr-FR",
@@ -40784,6 +41500,10 @@
           "seg": "Debug"
         },
         {
+          "lang": "es-ES",
+          "seg": "Depuración"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Debug"
         },
@@ -40807,6 +41527,10 @@
         {
           "lang": "en-US",
           "seg": "Socket start failed (code: {0}). Run the app as Administrator or switch to \"Npcap\" in Settings."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No se pudo iniciar el socket (código: {0}). Ejecuta la aplicación como administrador o cambia a \"Npcap\" en Configuración."
         },
         {
           "lang": "fr-FR",
@@ -40834,6 +41558,10 @@
           "seg": "Please run the application as Administrator."
         },
         {
+          "lang": "es-ES",
+          "seg": "Ejecuta la aplicación como administrador."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Veuillez exécuter l'application en tant qu'administrateur."
         },
@@ -40857,6 +41585,10 @@
         {
           "lang": "en-US",
           "seg": "Npcap (wpcap.dll) was not found. Please install or repair Npcap (without WinPcap legacy)."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No se encontró Npcap (wpcap.dll). Instala o repara Npcap (sin el modo heredado de WinPcap)."
         },
         {
           "lang": "fr-FR",
@@ -40884,6 +41616,10 @@
           "seg": "Npcap could not open an adapter. Check administrator rights, firewall/VPN, and the selected adapter."
         },
         {
+          "lang": "es-ES",
+          "seg": "Npcap no pudo abrir un adaptador. Comprueba los permisos de administrador, el firewall/VPN y el adaptador seleccionado."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Npcap n'a pas pu ouvrir d'adaptateur. Vérifiez les droits d'administrateur, le pare-feu/VPN et l'adaptateur sélectionné."
         },
@@ -40909,6 +41645,10 @@
           "seg": "Capture could not start in the current state. Please restart the app and verify adapter/filter settings."
         },
         {
+          "lang": "es-ES",
+          "seg": "La captura no pudo iniciarse en el estado actual. Reinicia la aplicación y verifica la configuración del adaptador/filtro."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Impossible de démarrer la capture dans l'état actuel. Veuillez redémarrer l'application et vérifier les paramètres de l'adaptateur et/ou du filtre."
         },
@@ -40932,6 +41672,10 @@
         {
           "lang": "en-US",
           "seg": "Tracking could not be started. Please verify installation and settings. (Install NPcap correct!)"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No se pudo iniciar el seguimiento. Verifica la instalación y la configuración. (¡Instala NPcap correctamente!)"
         },
         {
           "lang": "fr-FR",
@@ -41012,6 +41756,10 @@
           "seg": "There is no update available at the moment."
         },
         {
+          "lang": "es-ES",
+          "seg": "No hay ninguna actualización disponible en este momento."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Aucune mise à jour n'est disponible pour le moment."
         },
@@ -41035,6 +41783,10 @@
         {
           "lang": "en-US",
           "seg": "No Update Available"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No hay actualizaciones disponibles"
         },
         {
           "lang": "fr-FR",
@@ -41062,6 +41814,10 @@
           "seg": "There is a new version {0} available. You are currently using version {1}. This update is required. Press OK to begin updating the application."
         },
         {
+          "lang": "es-ES",
+          "seg": "Hay una nueva versión {0} disponible. Actualmente estás usando la versión {1}. Esta actualización es obligatoria. Pulsa Aceptar para comenzar a actualizar la aplicación."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Une nouvelle version {0} est disponible. Vous utilisez actuellement la version {1}. Cette mise à jour est requise. Appuyez sur OK pour lancer la mise à jour de l'application."
         },
@@ -41085,6 +41841,10 @@
         {
           "lang": "en-US",
           "seg": "There is a new version {0} available. You are currently using version {1}. Do you want to update the application now?"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Hay una nueva versión {0} disponible. Actualmente estás usando la versión {1}. ¿Quieres actualizar la aplicación ahora?"
         },
         {
           "lang": "fr-FR",
@@ -41112,6 +41872,10 @@
           "seg": "Update Available"
         },
         {
+          "lang": "es-ES",
+          "seg": "Actualización disponible"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Mise à jour disponible"
         },
@@ -41135,6 +41899,10 @@
         {
           "lang": "en-US",
           "seg": "{0} update available"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Actualización {0} disponible"
         },
         {
           "lang": "fr-FR",
@@ -41162,6 +41930,10 @@
           "seg": "Remind me later"
         },
         {
+          "lang": "es-ES",
+          "seg": "Recordármelo más tarde"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Me le rappeler plus tard"
         },
@@ -41185,6 +41957,10 @@
         {
           "lang": "en-US",
           "seg": "Downloading and preparing the update..."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Descargando y preparando la actualización..."
         },
         {
           "lang": "fr-FR",
@@ -41212,6 +41988,10 @@
           "seg": "Downloading..."
         },
         {
+          "lang": "es-ES",
+          "seg": "Descargando..."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Telechargement..."
         },
@@ -41237,6 +42017,10 @@
           "seg": "Download complete. Installing the update..."
         },
         {
+          "lang": "es-ES",
+          "seg": "Descarga completada. Instalando la actualización..."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Téléchargement terminé. Installation de la mise à jour en cours..."
         }
@@ -41252,6 +42036,10 @@
         {
           "lang": "en-US",
           "seg": "Installing..."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Instalando..."
         },
         {
           "lang": "fr-FR",
@@ -41271,6 +42059,10 @@
           "seg": "The update could not be downloaded. Please check your internet or proxy connection and try again."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudo descargar la actualización. Comprueba tu conexión a Internet o al proxy e inténtalo de nuevo."
+        },
+        {
           "lang": "fr-FR",
           "seg": "La mise à jour n'a pas pu être téléchargée. Veuillez vérifier votre connexion Internet ou votre proxy, puis réessayez."
         }
@@ -41288,6 +42080,10 @@
           "seg": "The update could not be installed automatically. Please try again or install it manually."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudo instalar la actualización automáticamente. Inténtalo de nuevo o instálala manualmente."
+        },
+        {
           "lang": "fr-FR",
           "seg": "La mise à jour n'a pas pu être installée automatiquement. Veuillez réessayer ou l'installer manuellement."
         }
@@ -41303,6 +42099,10 @@
         {
           "lang": "en-US",
           "seg": "There is a problem reaching the update server. Please check your internet connection and try again later."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Hay un problema al contactar con el servidor de actualizaciones. Comprueba tu conexión a Internet e inténtalo de nuevo más tarde."
         },
         {
           "lang": "fr-FR",
@@ -41328,6 +42128,10 @@
         {
           "lang": "en-US",
           "seg": "Update Check Failed"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Error al buscar actualizaciones"
         },
         {
           "lang": "fr-FR",
@@ -41461,6 +42265,10 @@
           "seg": "Item info window: The item info window can be opened by double-clicking the item directly in the list."
         },
         {
+          "lang": "es-ES",
+          "seg": "Ventana de información del objeto: puedes abrirla haciendo doble clic directamente sobre el objeto en la lista."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Fenêtre d'information de l'objet : la fenêtre d'information de l'objet peut être ouverte en double-cliquant directement sur l'objet dans la liste."
         },
@@ -41484,6 +42292,10 @@
         {
           "lang": "en-US",
           "seg": "Item alarm: Enter a value in the undercutting column and then activate the alarm in the is alarm active column."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Alarma de objeto: introduce un valor en la columna de subcotización y luego activa la alarma en la columna de alarma activa."
         },
         {
           "lang": "fr-FR",
@@ -41511,6 +42323,10 @@
           "seg": "Item prices: Prices below the item names in the list are average values taken directly from the game and update when items are viewed in-game."
         },
         {
+          "lang": "es-ES",
+          "seg": "Precios de objetos: los precios que aparecen debajo de los nombres de los objetos en la lista son valores promedio tomados directamente del juego y se actualizan cuando los objetos se visualizan dentro del juego."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix des objets : les prix affichés sous les noms d'objets dans la liste sont des valeurs moyennes issues directement du jeu et se mettent à jour lorsque les objets sont consultés en jeu."
         },
@@ -41534,6 +42350,10 @@
         {
           "lang": "en-US",
           "seg": "Delete all map history entries"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Eliminar todas las entradas del historial de mapas"
         },
         {
           "lang": "fr-FR",
@@ -41561,6 +42381,10 @@
           "seg": "Are you sure you want to delete all map history entries?"
         },
         {
+          "lang": "es-ES",
+          "seg": "¿Seguro que quieres eliminar todas las entradas del historial de mapas?"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Voulez-vous vraiment supprimer toutes les entrées de l'historique de carte ?"
         },
@@ -41584,6 +42408,10 @@
         {
           "lang": "en-US",
           "seg": "Time"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Hora"
         },
         {
           "lang": "fr-FR",
@@ -41611,6 +42439,10 @@
           "seg": "Zone"
         },
         {
+          "lang": "es-ES",
+          "seg": "Zona"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Zone"
         },
@@ -41634,6 +42466,10 @@
         {
           "lang": "en-US",
           "seg": "Number of gathered resources"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cantidad de recursos recolectados"
         },
         {
           "lang": "fr-FR",
@@ -41661,6 +42497,10 @@
           "seg": "Total silver value of resources"
         },
         {
+          "lang": "es-ES",
+          "seg": "Valor total en plata de los recursos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Valeur totale en argent des ressources"
         },
@@ -41684,6 +42524,10 @@
         {
           "lang": "en-US",
           "seg": "Aggregation"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Agrupación"
         },
         {
           "lang": "fr-FR",
@@ -41711,6 +42555,10 @@
           "seg": "Auto"
         },
         {
+          "lang": "es-ES",
+          "seg": "Automático"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Auto"
         },
@@ -41734,6 +42582,10 @@
         {
           "lang": "en-US",
           "seg": "autosave"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "guardado automático"
         },
         {
           "lang": "fr-FR",
@@ -41761,6 +42613,10 @@
           "seg": "Hour"
         },
         {
+          "lang": "es-ES",
+          "seg": "Hora"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Heure"
         },
@@ -41784,6 +42640,10 @@
         {
           "lang": "en-US",
           "seg": "Profit over Time"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio a lo largo del tiempo"
         },
         {
           "lang": "fr-FR",
@@ -41811,6 +42671,10 @@
           "seg": "Profit by Time of Day"
         },
         {
+          "lang": "es-ES",
+          "seg": "Beneficio por hora del día"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Profit selon l'heure de la journée"
         },
@@ -41834,6 +42698,10 @@
         {
           "lang": "en-US",
           "seg": "Display"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Visualización"
         },
         {
           "lang": "fr-FR",
@@ -41861,6 +42729,10 @@
           "seg": "Metric"
         },
         {
+          "lang": "es-ES",
+          "seg": "Métrica"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Système métrique"
         },
@@ -41884,6 +42756,10 @@
         {
           "lang": "en-US",
           "seg": "Heatmap"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mapa de calor"
         },
         {
           "lang": "fr-FR",
@@ -41911,6 +42787,10 @@
           "seg": "Hourly Bars"
         },
         {
+          "lang": "es-ES",
+          "seg": "Barras por hora"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Barres horaires"
         },
@@ -41934,6 +42814,10 @@
         {
           "lang": "en-US",
           "seg": "Average Profit per Trade"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio promedio por intercambio"
         },
         {
           "lang": "fr-FR",
@@ -41961,6 +42845,10 @@
           "seg": "Trade count"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cantidad de intercambios"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nombre de transactions"
         },
@@ -41984,6 +42872,10 @@
         {
           "lang": "en-US",
           "seg": "Top Item Ranking"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Clasificación de mejores objetos"
         },
         {
           "lang": "fr-FR",
@@ -42011,6 +42903,10 @@
           "seg": "Top Transfer by Profit"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejor transferencia por beneficio"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleur transfert en termes de profit"
         },
@@ -42034,6 +42930,10 @@
         {
           "lang": "en-US",
           "seg": "Top Transfer by Loss"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Peor transferencia por pérdida"
         },
         {
           "lang": "fr-FR",
@@ -42061,6 +42961,10 @@
           "seg": "Top Items by ROI"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejores objetos por ROI"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleurs articles par ROI (Retour Sur Investissement)"
         },
@@ -42084,6 +42988,10 @@
         {
           "lang": "en-US",
           "seg": "Top sold items by volume"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Objetos más vendidos por volumen"
         },
         {
           "lang": "fr-FR",
@@ -42111,6 +43019,10 @@
           "seg": "Top bought items by volume"
         },
         {
+          "lang": "es-ES",
+          "seg": "Objetos más comprados por volumen"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Objets les plus achetés en volume"
         },
@@ -42133,6 +43045,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "ROI"
+        },
+        {
+          "lang": "es-ES",
           "seg": "ROI"
         },
         {
@@ -42161,6 +43077,10 @@
           "seg": "Received"
         },
         {
+          "lang": "es-ES",
+          "seg": "Recibido"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Reçu"
         },
@@ -42184,6 +43104,10 @@
         {
           "lang": "en-US",
           "seg": "Given"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Entregado"
         },
         {
           "lang": "fr-FR",
@@ -42211,6 +43135,10 @@
           "seg": "Recognize personal trades"
         },
         {
+          "lang": "es-ES",
+          "seg": "Reconocer intercambios personales"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Identifier ses propres transactions"
         },
@@ -42234,6 +43162,10 @@
         {
           "lang": "en-US",
           "seg": "Damage Stats"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Estadísticas de daño"
         },
         {
           "lang": "fr-FR",
@@ -42261,6 +43193,10 @@
           "seg": "Live"
         },
         {
+          "lang": "es-ES",
+          "seg": "En vivo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Live"
         },
@@ -42284,6 +43220,10 @@
         {
           "lang": "en-US",
           "seg": "Meter"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Medidor"
         },
         {
           "lang": "fr-FR",
@@ -42311,6 +43251,10 @@
           "seg": "Stats"
         },
         {
+          "lang": "es-ES",
+          "seg": "Estadísticas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Stats"
         },
@@ -42334,6 +43278,10 @@
         {
           "lang": "en-US",
           "seg": "Top Stats"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mejores estadísticas"
         },
         {
           "lang": "fr-FR",
@@ -42361,6 +43309,10 @@
           "seg": "Your Stats"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tus estadísticas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Vos Stats"
         },
@@ -42384,6 +43336,10 @@
         {
           "lang": "en-US",
           "seg": "No local damage data available"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No hay datos locales de daño disponibles"
         },
         {
           "lang": "fr-FR",
@@ -42411,6 +43367,10 @@
           "seg": "Total damage"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Total des dégâts"
         },
@@ -42434,6 +43394,10 @@
         {
           "lang": "en-US",
           "seg": "Damage"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño"
         },
         {
           "lang": "fr-FR",
@@ -42461,6 +43425,10 @@
           "seg": "Healing"
         },
         {
+          "lang": "es-ES",
+          "seg": "Curación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Soins"
         },
@@ -42484,6 +43452,10 @@
         {
           "lang": "en-US",
           "seg": "Defense"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Defensa"
         },
         {
           "lang": "fr-FR",
@@ -42511,6 +43483,10 @@
           "seg": "Combat"
         },
         {
+          "lang": "es-ES",
+          "seg": "Combate"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Combat"
         },
@@ -42534,6 +43510,10 @@
         {
           "lang": "en-US",
           "seg": "Total DPS"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "DPS total"
         },
         {
           "lang": "fr-FR",
@@ -42561,6 +43541,10 @@
           "seg": "Peak DPS 3s"
         },
         {
+          "lang": "es-ES",
+          "seg": "DPS máximo en 3 s"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Peak DPS 3s"
         },
@@ -42584,6 +43568,10 @@
         {
           "lang": "en-US",
           "seg": "Peak DPS 5s"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "DPS máximo en 5 s"
         },
         {
           "lang": "fr-FR",
@@ -42611,6 +43599,10 @@
           "seg": "Peak DPS 10s"
         },
         {
+          "lang": "es-ES",
+          "seg": "DPS máximo en 10 s"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Peak DPS 10s"
         },
@@ -42634,6 +43626,10 @@
         {
           "lang": "en-US",
           "seg": "Biggest Hit"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Golpe más fuerte"
         },
         {
           "lang": "fr-FR",
@@ -42661,6 +43657,10 @@
           "seg": "Total Healing"
         },
         {
+          "lang": "es-ES",
+          "seg": "Curación total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Total des Soins"
         },
@@ -42684,6 +43684,10 @@
         {
           "lang": "en-US",
           "seg": "Effective Healing"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Curación efectiva"
         },
         {
           "lang": "fr-FR",
@@ -42711,6 +43715,10 @@
           "seg": "Overheal %"
         },
         {
+          "lang": "es-ES",
+          "seg": "Sobrecuración %"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Overheal %"
         },
@@ -42734,6 +43742,10 @@
         {
           "lang": "en-US",
           "seg": "Damage Taken"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño recibido"
         },
         {
           "lang": "fr-FR",
@@ -42761,6 +43773,10 @@
           "seg": "Biggest Damage Taken by Spell"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mayor daño recibido por habilidad"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dégâts les plus importants subis par un sort"
         },
@@ -42783,6 +43799,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "DTPS"
+        },
+        {
+          "lang": "es-ES",
           "seg": "DTPS"
         },
         {
@@ -42811,6 +43831,10 @@
           "seg": "DTPS is incoming damage per second: Damage Taken / active combat time."
         },
         {
+          "lang": "es-ES",
+          "seg": "DTPS es el daño recibido por segundo: Daño recibido / tiempo de combate activo."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Le DTPS correspond aux dégâts subis par seconde : dégâts subis / durée du combat."
         },
@@ -42834,6 +43858,10 @@
         {
           "lang": "en-US",
           "seg": "Fight Count"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cantidad de combates"
         },
         {
           "lang": "fr-FR",
@@ -42861,6 +43889,10 @@
           "seg": "Average Fight Duration"
         },
         {
+          "lang": "es-ES",
+          "seg": "Duración promedio de los combates"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Durée moyenne d'un combat"
         },
@@ -42884,6 +43916,10 @@
         {
           "lang": "en-US",
           "seg": "PvE Damage"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño PvE"
         },
         {
           "lang": "fr-FR",
@@ -42911,6 +43947,10 @@
           "seg": "PvP Damage"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño PvP"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dégâts PvP"
         },
@@ -42934,6 +43974,10 @@
         {
           "lang": "en-US",
           "seg": "Healing Targets"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Objetivos de curación"
         },
         {
           "lang": "fr-FR",
@@ -42961,6 +44005,10 @@
           "seg": "Biggest single hit - TOP 5"
         },
         {
+          "lang": "es-ES",
+          "seg": "Golpe individual más fuerte - TOP 5"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Le plus gros coup en une fois - TOP 5"
         },
@@ -42984,6 +44032,10 @@
         {
           "lang": "en-US",
           "seg": "Biggest single heal - TOP 5"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mayor curación individual - TOP 5"
         },
         {
           "lang": "fr-FR",
@@ -43011,6 +44063,10 @@
           "seg": "Last hits - TOP 5"
         },
         {
+          "lang": "es-ES",
+          "seg": "Últimos golpes - TOP 5"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dernier coup - TOP 5"
         },
@@ -43034,6 +44090,10 @@
         {
           "lang": "en-US",
           "seg": "Overheal - TOP 5"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Sobrecuración - TOP 5"
         },
         {
           "lang": "fr-FR",
@@ -43061,6 +44121,10 @@
           "seg": "Damage taken - TOP 5"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño recibido - TOP 5"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dégâts subis - TOP 5"
         },
@@ -43084,6 +44148,10 @@
         {
           "lang": "en-US",
           "seg": "Burst Damage 5 seconds - TOP 5"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño explosivo en 5 segundos - TOP 5"
         },
         {
           "lang": "fr-FR",
@@ -43111,6 +44179,10 @@
           "seg": "Burst Damage 10 seconds - TOP 5"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño explosivo en 10 segundos - TOP 5"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Burst Damage 10 seconds - TOP 5"
         },
@@ -43134,6 +44206,10 @@
         {
           "lang": "en-US",
           "seg": "Attacked mobs / players - TOP 5"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mobs / jugadores atacados - TOP 5"
         },
         {
           "lang": "fr-FR",
@@ -43161,6 +44237,10 @@
           "seg": "Number of runs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Número de ejecuciones"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nombre de tours"
         },
@@ -43184,6 +44264,10 @@
         {
           "lang": "en-US",
           "seg": "Focus"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Foco"
         },
         {
           "lang": "fr-FR",
@@ -43211,6 +44295,10 @@
           "seg": "Daily bonus RRR"
         },
         {
+          "lang": "es-ES",
+          "seg": "Bonificación diaria de RRR"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Bonus Quotidien RRR"
         },
@@ -43234,6 +44322,10 @@
         {
           "lang": "en-US",
           "seg": "Hideout bonus"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Bonificación del escondite"
         },
         {
           "lang": "fr-FR",
@@ -43261,6 +44353,10 @@
           "seg": "Crafting location"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ubicación de fabricación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Emplacement de fabrication"
         },
@@ -43284,6 +44380,10 @@
         {
           "lang": "en-US",
           "seg": "Return rate %"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tasa de devolución %"
         },
         {
           "lang": "fr-FR",
@@ -43311,6 +44411,10 @@
           "seg": "Price market"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mercado de precios"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix du marché"
         },
@@ -43334,6 +44438,10 @@
         {
           "lang": "en-US",
           "seg": "Station fee"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tarifa de estación"
         },
         {
           "lang": "fr-FR",
@@ -43361,6 +44469,10 @@
           "seg": "Usage fee / 100 food"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tarifa de uso / 100 de comida"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Frais d'utilisation / 100 nourritures"
         },
@@ -43384,6 +44496,10 @@
         {
           "lang": "en-US",
           "seg": "Sales tax %"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Impuesto de venta %"
         },
         {
           "lang": "fr-FR",
@@ -43411,6 +44527,10 @@
           "seg": "Sell price"
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio de venta"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix de vente"
         },
@@ -43434,6 +44554,10 @@
         {
           "lang": "en-US",
           "seg": "New"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Nuevo"
         },
         {
           "lang": "fr-FR",
@@ -43461,6 +44585,10 @@
           "seg": "Delete"
         },
         {
+          "lang": "es-ES",
+          "seg": "Eliminar"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Supprimer"
         },
@@ -43484,6 +44612,10 @@
         {
           "lang": "en-US",
           "seg": "Prices"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Precios"
         },
         {
           "lang": "fr-FR",
@@ -43511,6 +44643,10 @@
           "seg": "Resources"
         },
         {
+          "lang": "es-ES",
+          "seg": "Recursos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Resources"
         },
@@ -43534,6 +44670,10 @@
         {
           "lang": "en-US",
           "seg": "Gross"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Bruto"
         },
         {
           "lang": "fr-FR",
@@ -43561,6 +44701,10 @@
           "seg": "Expected return"
         },
         {
+          "lang": "es-ES",
+          "seg": "Devolución esperada"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Rendement attendu"
         },
@@ -43584,6 +44728,10 @@
         {
           "lang": "en-US",
           "seg": "Net"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Neto"
         },
         {
           "lang": "fr-FR",
@@ -43611,6 +44759,10 @@
           "seg": "Price"
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix"
         },
@@ -43634,6 +44786,10 @@
         {
           "lang": "en-US",
           "seg": "Net cost"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costo neto"
         },
         {
           "lang": "fr-FR",
@@ -43661,6 +44817,10 @@
           "seg": "Shows the resource icon."
         },
         {
+          "lang": "es-ES",
+          "seg": "Muestra el icono del recurso."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Affiche l'icone de la ressource."
         },
@@ -43684,6 +44844,10 @@
         {
           "lang": "en-US",
           "seg": "Name of the required resource."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Nombre del recurso requerido."
         },
         {
           "lang": "fr-FR",
@@ -43711,6 +44875,10 @@
           "seg": "Resource type, for example returnable, non-returnable, or special resource."
         },
         {
+          "lang": "es-ES",
+          "seg": "Tipo de recurso, por ejemplo retornable, no retornable o recurso especial."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Type de ressource, par exemple retournable, non retournable ou speciale."
         },
@@ -43734,6 +44902,10 @@
         {
           "lang": "en-US",
           "seg": "Gross requirement before resource return."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cantidad bruta requerida antes de la devolución de recursos."
         },
         {
           "lang": "fr-FR",
@@ -43761,6 +44933,10 @@
           "seg": "Expected return from the resource return rate."
         },
         {
+          "lang": "es-ES",
+          "seg": "Devolución esperada según la tasa de devolución de recursos."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Retour attendu par le taux de retour des ressources."
         },
@@ -43784,6 +44960,10 @@
         {
           "lang": "en-US",
           "seg": "Net consumption after expected return."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Consumo neto después de la devolución esperada."
         },
         {
           "lang": "fr-FR",
@@ -43811,6 +44991,10 @@
           "seg": "Silver price per resource unit."
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio en plata por unidad de recurso."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix en argent par unite de ressource."
         },
@@ -43834,6 +45018,10 @@
         {
           "lang": "en-US",
           "seg": "Silver cost after expected return."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costo en plata después de la devolución esperada."
         },
         {
           "lang": "fr-FR",
@@ -43861,6 +45049,10 @@
           "seg": "Journals"
         },
         {
+          "lang": "es-ES",
+          "seg": "Diarios"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Registres"
         },
@@ -43884,6 +45076,10 @@
         {
           "lang": "en-US",
           "seg": "Empty price"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Precio vacío"
         },
         {
           "lang": "fr-FR",
@@ -43911,6 +45107,10 @@
           "seg": "Full price"
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio lleno"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix total"
         },
@@ -43934,6 +45134,10 @@
         {
           "lang": "en-US",
           "seg": "Empty"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Vacío"
         },
         {
           "lang": "fr-FR",
@@ -43961,6 +45165,10 @@
           "seg": "Full"
         },
         {
+          "lang": "es-ES",
+          "seg": "Lleno"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Complet"
         },
@@ -43984,6 +45192,10 @@
         {
           "lang": "en-US",
           "seg": "Partial"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Parcial"
         },
         {
           "lang": "fr-FR",
@@ -44011,6 +45223,10 @@
           "seg": "Results"
         },
         {
+          "lang": "es-ES",
+          "seg": "Resultados"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Résultats"
         },
@@ -44034,6 +45250,10 @@
         {
           "lang": "en-US",
           "seg": "Output"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Producción"
         },
         {
           "lang": "fr-FR",
@@ -44061,6 +45281,10 @@
           "seg": "Sales net"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ventas netas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chiffre d'affaires net"
         },
@@ -44084,6 +45308,10 @@
         {
           "lang": "en-US",
           "seg": "Gross materials"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Materiales brutos"
         },
         {
           "lang": "fr-FR",
@@ -44111,6 +45339,10 @@
           "seg": "Net materials"
         },
         {
+          "lang": "es-ES",
+          "seg": "Materiales netos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Matériau Net"
         },
@@ -44134,6 +45366,10 @@
         {
           "lang": "en-US",
           "seg": "Non-returnable"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No retornable"
         },
         {
           "lang": "fr-FR",
@@ -44161,6 +45397,10 @@
           "seg": "Station"
         },
         {
+          "lang": "es-ES",
+          "seg": "Estación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Station"
         },
@@ -44184,6 +45424,10 @@
         {
           "lang": "en-US",
           "seg": "Journal costs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costos de diarios"
         },
         {
           "lang": "fr-FR",
@@ -44211,6 +45455,10 @@
           "seg": "Journal revenue"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ingresos por diarios"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Recette des registres"
         },
@@ -44234,6 +45482,10 @@
         {
           "lang": "en-US",
           "seg": "Weight before"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Peso antes"
         },
         {
           "lang": "fr-FR",
@@ -44261,6 +45513,10 @@
           "seg": "Weight after"
         },
         {
+          "lang": "es-ES",
+          "seg": "Peso después"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Poids après"
         },
@@ -44284,6 +45540,10 @@
         {
           "lang": "en-US",
           "seg": "Saved craftings"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Fabricaciones guardadas"
         },
         {
           "lang": "fr-FR",
@@ -44311,6 +45571,10 @@
           "seg": "Item"
         },
         {
+          "lang": "es-ES",
+          "seg": "Objeto"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Objet"
         },
@@ -44334,6 +45598,10 @@
         {
           "lang": "en-US",
           "seg": "Details"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Detalles"
         },
         {
           "lang": "fr-FR",
@@ -44361,6 +45629,10 @@
           "seg": "Main costs"
         },
         {
+          "lang": "es-ES",
+          "seg": "Costos principales"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coûts principaux"
         },
@@ -44384,6 +45656,10 @@
         {
           "lang": "en-US",
           "seg": "Changed"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cambiado"
         },
         {
           "lang": "fr-FR",
@@ -44411,6 +45687,10 @@
           "seg": "None"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ninguno"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Aucun(e)"
         },
@@ -44436,6 +45716,10 @@
           "seg": "Volume"
         },
         {
+          "lang": "es-ES",
+          "seg": "Volumen"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Volume"
         }
@@ -44451,6 +45735,10 @@
         {
           "lang": "en-US",
           "seg": "Expected RRR"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "RRR esperado"
         },
         {
           "lang": "fr-FR",
@@ -44478,6 +45766,10 @@
           "seg": "No focus"
         },
         {
+          "lang": "es-ES",
+          "seg": "Sin foco"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Pas de focalisation"
         },
@@ -44501,6 +45793,10 @@
         {
           "lang": "en-US",
           "seg": "Daily"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Diario"
         },
         {
           "lang": "fr-FR",
@@ -44528,6 +45824,10 @@
           "seg": "runs"
         },
         {
+          "lang": "es-ES",
+          "seg": "ejecuciones"
+        },
+        {
           "lang": "fr-FR",
           "seg": "tours"
         },
@@ -44551,6 +45851,10 @@
         {
           "lang": "en-US",
           "seg": "Select an item before saving."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Selecciona un objeto antes de guardar."
         },
         {
           "lang": "fr-FR",
@@ -44578,6 +45882,10 @@
           "seg": "Crafting saved."
         },
         {
+          "lang": "es-ES",
+          "seg": "Fabricación guardada."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Fabrications enregistrées."
         },
@@ -44601,6 +45909,10 @@
         {
           "lang": "en-US",
           "seg": "Crafting deleted."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Fabricación eliminada."
         },
         {
           "lang": "fr-FR",
@@ -44628,6 +45940,10 @@
           "seg": "Crafting loaded."
         },
         {
+          "lang": "es-ES",
+          "seg": "Fabricación cargada."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Fabrications chargées."
         },
@@ -44651,6 +45967,10 @@
         {
           "lang": "en-US",
           "seg": "New crafting started."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Se inició una nueva fabricación."
         },
         {
           "lang": "fr-FR",
@@ -44678,6 +45998,10 @@
           "seg": "Select an item before loading prices."
         },
         {
+          "lang": "es-ES",
+          "seg": "Selecciona un objeto antes de cargar los precios."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Sélectionnez un objet avant d'afficher les prix."
         },
@@ -44701,6 +46025,10 @@
         {
           "lang": "en-US",
           "seg": "Market prices loaded."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Precios del mercado cargados."
         },
         {
           "lang": "fr-FR",
@@ -44728,6 +46056,10 @@
           "seg": "Market prices could not be loaded."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudieron cargar los precios del mercado."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Sélectionnez un objet avant d'afficher les prix."
         },
@@ -44751,6 +46083,10 @@
         {
           "lang": "en-US",
           "seg": "Standard"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Estándar"
         },
         {
           "lang": "fr-FR",
@@ -44778,6 +46114,10 @@
           "seg": "Artefact"
         },
         {
+          "lang": "es-ES",
+          "seg": "Artefacto"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Artefact"
         },
@@ -44801,6 +46141,10 @@
         {
           "lang": "en-US",
           "seg": "Alchemy"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Alquimia"
         },
         {
           "lang": "fr-FR",
@@ -44828,6 +46172,10 @@
           "seg": "Avalonian energy"
         },
         {
+          "lang": "es-ES",
+          "seg": "Energía avaloniana"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Energie Avalonienne"
         },
@@ -44851,6 +46199,10 @@
         {
           "lang": "en-US",
           "seg": "Tome of insight"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tomo de perspicacia"
         },
         {
           "lang": "fr-FR",
@@ -44878,6 +46230,10 @@
           "seg": "Essence"
         },
         {
+          "lang": "es-ES",
+          "seg": "Esencia"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Essence"
         },
@@ -44901,6 +46257,10 @@
         {
           "lang": "en-US",
           "seg": "Special"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Especial"
         },
         {
           "lang": "fr-FR",
@@ -44928,6 +46288,10 @@
           "seg": "Sales gross"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ventas brutas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chiffre d'affaires brut"
         },
@@ -44951,6 +46315,10 @@
         {
           "lang": "en-US",
           "seg": "Sales tax"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Impuesto de venta"
         },
         {
           "lang": "fr-FR",
@@ -44978,6 +46346,10 @@
           "seg": "Number of items produced by the entered crafting runs."
         },
         {
+          "lang": "es-ES",
+          "seg": "Número de objetos producidos por las ejecuciones de fabricación introducidas."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nombre d'objets produits lors des sessions de fabrication indiquées."
         },
@@ -45001,6 +46373,10 @@
         {
           "lang": "en-US",
           "seg": "Profit after material costs, station costs, other costs, taxes, journal costs, and journal revenue."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio después de los costos de materiales, estación, otros costos, impuestos, costos de diarios e ingresos por diarios."
         },
         {
           "lang": "fr-FR",
@@ -45028,6 +46404,10 @@
           "seg": "Profit divided by the produced output quantity."
         },
         {
+          "lang": "es-ES",
+          "seg": "Beneficio dividido entre la cantidad de objetos producidos."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Bénéfice après déduction des coûts des matières premières, des frais de station, des autres coûts, des taxes, des coûts liés aux registres et des recettes provenant des registres."
         },
@@ -45051,6 +46431,10 @@
         {
           "lang": "en-US",
           "seg": "Profit relative to total invested costs."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Beneficio en relación con los costos totales invertidos."
         },
         {
           "lang": "fr-FR",
@@ -45078,6 +46462,10 @@
           "seg": "Minimum sell price per item where profit is zero."
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio mínimo de venta por objeto en el que el beneficio es cero."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix de vente minimum par objet pour lequel le bénéfice est nul."
         },
@@ -45101,6 +46489,10 @@
         {
           "lang": "en-US",
           "seg": "Sales revenue before sales tax."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Ingresos por ventas antes del impuesto de venta."
         },
         {
           "lang": "fr-FR",
@@ -45128,6 +46520,10 @@
           "seg": "Sales tax deducted from gross sales."
         },
         {
+          "lang": "es-ES",
+          "seg": "Impuesto de venta deducido de las ventas brutas."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chiffre d'affaires hors taxes."
         },
@@ -45151,6 +46547,10 @@
         {
           "lang": "en-US",
           "seg": "Sales revenue after sales tax and setup fee."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Ingresos por ventas después del impuesto de venta y la tarifa de publicación."
         },
         {
           "lang": "fr-FR",
@@ -45178,6 +46578,10 @@
           "seg": "Setup fee deducted from gross sales."
         },
         {
+          "lang": "es-ES",
+          "seg": "Tarifa de publicación deducida de las ventas brutas."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Frais d'installation dÃƒÂ©duits du chiffre d'affaires brut."
         },
@@ -45201,6 +46605,10 @@
         {
           "lang": "en-US",
           "seg": "Total invested costs from net materials, station costs, journal costs, and other costs."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costos totales invertidos de materiales netos, costos de estación, costos de diarios y otros costos."
         },
         {
           "lang": "fr-FR",
@@ -45228,6 +46636,10 @@
           "seg": "Material costs before resource return rate."
         },
         {
+          "lang": "es-ES",
+          "seg": "Costos de materiales antes de la tasa de devolución de recursos."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coûts des matériaux avant prise en compte du taux de récupération des ressources."
         },
@@ -45251,6 +46663,10 @@
         {
           "lang": "en-US",
           "seg": "Material costs after expected resource return rate."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costos de materiales después de la tasa esperada de devolución de recursos."
         },
         {
           "lang": "fr-FR",
@@ -45278,6 +46694,10 @@
           "seg": "Costs for resources that are not returned by resource return."
         },
         {
+          "lang": "es-ES",
+          "seg": "Costos de los recursos que no se devuelven mediante la devolución de recursos."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Frais liés aux ressources qui ne sont pas restituées dans le processus de restitution des ressources."
         },
@@ -45301,6 +46721,10 @@
         {
           "lang": "en-US",
           "seg": "Calculated station cost from usage fee per 100 food and the item's consumed food."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costo de estación calculado a partir de la tarifa de uso por 100 de comida y la comida consumida por el objeto."
         },
         {
           "lang": "fr-FR",
@@ -45328,6 +46752,10 @@
           "seg": "Manually entered additional costs included in profit, ROI, and break-even price."
         },
         {
+          "lang": "es-ES",
+          "seg": "Costos adicionales introducidos manualmente e incluidos en el beneficio, ROI y precio de equilibrio."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Les coûts supplémentaires saisis manuellement sont pris en compte dans le bénéfice, le retour sur investissement et le prix d'équilibre."
         },
@@ -45351,6 +46779,10 @@
         {
           "lang": "en-US",
           "seg": "Costs of the required empty journals."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Costos de los diarios vacíos requeridos."
         },
         {
           "lang": "fr-FR",
@@ -45378,6 +46810,10 @@
           "seg": "Expected revenue from full journals."
         },
         {
+          "lang": "es-ES",
+          "seg": "Ingresos esperados de los diarios llenos."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chiffre d'affaires prévu pour les registres complets."
         },
@@ -45401,6 +46837,10 @@
         {
           "lang": "en-US",
           "seg": "Total weight of resources and journals before crafting."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Peso total de los recursos y diarios antes de fabricar."
         },
         {
           "lang": "fr-FR",
@@ -45428,6 +46868,10 @@
           "seg": "Total weight of crafted items and journals after crafting."
         },
         {
+          "lang": "es-ES",
+          "seg": "Peso total de los objetos fabricados y diarios después de fabricar."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Poids total des objets fabriqués et des registres après la fabrication."
         },
@@ -45451,6 +46895,10 @@
         {
           "lang": "en-US",
           "seg": "Setup guide"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Guía de configuración"
         },
         {
           "lang": "fr-FR",
@@ -45478,6 +46926,10 @@
           "seg": "Setup guide"
         },
         {
+          "lang": "es-ES",
+          "seg": "Guía de configuración"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Assistant de configuration"
         },
@@ -45501,6 +46953,10 @@
         {
           "lang": "en-US",
           "seg": "Choose the language the tool should use."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Elige el idioma que debe usar la herramienta."
         },
         {
           "lang": "fr-FR",
@@ -45528,6 +46984,10 @@
           "seg": "Please select a language."
         },
         {
+          "lang": "es-ES",
+          "seg": "Selecciona un idioma."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Veuillez sélectionner une langue."
         },
@@ -45551,6 +47011,10 @@
         {
           "lang": "en-US",
           "seg": "Tracking mode"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Modo de seguimiento"
         },
         {
           "lang": "fr-FR",
@@ -45578,6 +47042,10 @@
           "seg": "Choose how the tool should capture Albion Online network traffic."
         },
         {
+          "lang": "es-ES",
+          "seg": "Elige cómo debe capturar la herramienta el tráfico de red de Albion Online."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Choisissez comment l'outil doit capturer le trafic réseau d'Albion Online."
         },
@@ -45603,6 +47071,10 @@
           "seg": "NPCap uses a network driver and is usually the better first choice for most users. Socket uses Windows raw sockets and does not require NPCap, but the tool must be started as Administrator."
         },
         {
+          "lang": "es-ES",
+          "seg": "NPCap usa un controlador de red y suele ser la mejor primera opción para la mayoría de los usuarios. Socket usa sockets sin procesar de Windows y no requiere NPCap, pero la herramienta debe iniciarse como administrador."
+        },
+        {
           "lang": "fr-FR",
           "seg": "NPCap utilise un pilote réseau et constitue généralement le meilleur choix pour la plupart des utilisateurs. Socket utilise les sockets bruts de Windows et ne nécessite pas NPCap, mais l'outil doit être lancé en tant qu'administrateur."
         },
@@ -45625,6 +47097,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "NPCap"
+        },
+        {
+          "lang": "es-ES",
           "seg": "NPCap"
         },
         {
@@ -45653,6 +47129,10 @@
           "seg": "Socket"
         },
         {
+          "lang": "es-ES",
+          "seg": "Socket"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Socket"
         },
@@ -45676,6 +47156,10 @@
         {
           "lang": "en-US",
           "seg": "For NPCap, install NPCap."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Para usar NPCap, instala NPCap."
         },
         {
           "lang": "fr-FR",
@@ -45703,6 +47187,10 @@
           "seg": "Download NPCap"
         },
         {
+          "lang": "es-ES",
+          "seg": "Descargar NPCap"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Téléchargez NPCap"
         },
@@ -45726,6 +47214,10 @@
         {
           "lang": "en-US",
           "seg": "For Socket, start this tool as Administrator."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Para usar Socket, inicia esta herramienta como administrador."
         },
         {
           "lang": "fr-FR",
@@ -45753,6 +47245,10 @@
           "seg": "Please select a tracking mode."
         },
         {
+          "lang": "es-ES",
+          "seg": "Selecciona un modo de seguimiento."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Veuillez sélectionner un mode de suivi."
         },
@@ -45776,6 +47272,10 @@
         {
           "lang": "en-US",
           "seg": "Select the navigation tabs you want to see."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Selecciona las pestañas de navegación que quieres ver."
         },
         {
           "lang": "fr-FR",
@@ -45803,6 +47303,10 @@
           "seg": "Back"
         },
         {
+          "lang": "es-ES",
+          "seg": "Atrás"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Retour"
         },
@@ -45828,6 +47332,10 @@
           "seg": "Next"
         },
         {
+          "lang": "es-ES",
+          "seg": "Siguiente"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Suivant"
         },
@@ -45851,6 +47359,10 @@
         {
           "lang": "en-US",
           "seg": "Finish"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Finalizar"
         },
         {
           "lang": "fr-FR",
@@ -45927,6 +47439,10 @@
           "seg": "Loot Logger Stats"
         },
         {
+          "lang": "es-ES",
+          "seg": "Estadísticas del registrador de botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Loot Logger Stats"
         },
@@ -45950,6 +47466,10 @@
         {
           "lang": "en-US",
           "seg": "Loot"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Botín"
         },
         {
           "lang": "fr-FR",
@@ -45977,6 +47497,10 @@
           "seg": "Silver"
         },
         {
+          "lang": "es-ES",
+          "seg": "Plata"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Argent"
         },
@@ -46002,6 +47526,10 @@
           "seg": "Fame"
         },
         {
+          "lang": "es-ES",
+          "seg": "Fama"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Renommée"
         },
@@ -46025,6 +47553,10 @@
         {
           "lang": "en-US",
           "seg": "Faction"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Facción"
         },
         {
           "lang": "fr-FR",
@@ -46101,6 +47633,10 @@
           "seg": "Loot Value per Hour"
         },
         {
+          "lang": "es-ES",
+          "seg": "Valor del botín por hora"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Valeur du butin par heure"
         },
@@ -46124,6 +47660,10 @@
         {
           "lang": "en-US",
           "seg": "Fame per Hour"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Fama por hora"
         },
         {
           "lang": "fr-FR",
@@ -46151,6 +47691,10 @@
           "seg": "Silver per Hour"
         },
         {
+          "lang": "es-ES",
+          "seg": "Plata por hora"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Argent par Heure"
         },
@@ -46174,6 +47718,10 @@
         {
           "lang": "en-US",
           "seg": "Faction Points total"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Puntos de facción totales"
         },
         {
           "lang": "fr-FR",
@@ -46201,6 +47749,10 @@
           "seg": "Faction Points per Hour"
         },
         {
+          "lang": "es-ES",
+          "seg": "Puntos de facción por hora"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Points de Faction par Heure"
         },
@@ -46224,6 +47776,10 @@
         {
           "lang": "en-US",
           "seg": "Best Single Item"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mejor objeto individual"
         },
         {
           "lang": "fr-FR",
@@ -46251,6 +47807,10 @@
           "seg": "Highest Looted Value"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mayor valor de botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Valeur maximale de butin"
         },
@@ -46274,6 +47834,10 @@
         {
           "lang": "en-US",
           "seg": "Most Looted Items"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Objetos más saqueados"
         },
         {
           "lang": "fr-FR",
@@ -46301,6 +47865,10 @@
           "seg": "Most Kills"
         },
         {
+          "lang": "es-ES",
+          "seg": "Más asesinatos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Le plus grand nombre de Kills"
         },
@@ -46324,6 +47892,10 @@
         {
           "lang": "en-US",
           "seg": "Most Deaths"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Más muertes"
         },
         {
           "lang": "fr-FR",
@@ -46351,6 +47923,10 @@
           "seg": "Highest Kill Value"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mayor valor de asesinato"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleur valeur de Kill"
         },
@@ -46374,6 +47950,10 @@
         {
           "lang": "en-US",
           "seg": "Killer"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Asesino"
         },
         {
           "lang": "fr-FR",
@@ -46401,6 +47981,10 @@
           "seg": "No Loot Logger stats available yet."
         },
         {
+          "lang": "es-ES",
+          "seg": "Aún no hay estadísticas del registrador de botín disponibles."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Aucune statistique de Loot Logger n'est encore disponible."
         },
@@ -46426,6 +48010,10 @@
           "seg": "Startup server for app user data"
         },
         {
+          "lang": "es-ES",
+          "seg": "Servidor inicial para los datos de usuario de la aplicación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Serveur de démarrage pour les données utilisateur de l'application"
         },
@@ -46445,6 +48033,10 @@
         {
           "lang": "en-US",
           "seg": "This selection controls which server data is loaded when the app starts before Albion Online has been detected from network packets. While playing, the server is detected automatically; when the server changes, the current data is saved first and then the matching server data is loaded."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Esta selección controla qué datos del servidor se cargan al iniciar la aplicación antes de que Albion Online sea detectado mediante paquetes de red. Mientras juegas, el servidor se detecta automáticamente; cuando cambia el servidor, primero se guardan los datos actuales y luego se cargan los datos del servidor correspondiente."
         },
         {
           "lang": "fr-FR",
@@ -46468,6 +48060,10 @@
           "seg": "Startup data server"
         },
         {
+          "lang": "es-ES",
+          "seg": "Servidor de datos inicial"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Démarrage du serveur de données"
         },
@@ -46489,6 +48085,10 @@
           "seg": "Choose which server data should be loaded when the app starts and Albion Online is not active yet. Once you play, the tool detects the Albion server automatically from network packets and switches datasets automatically if you change servers. The currently loaded data is saved before every switch."
         },
         {
+          "lang": "es-ES",
+          "seg": "Elige qué datos del servidor deben cargarse al iniciar la aplicación cuando Albion Online aún no está activo. Una vez que juegas, la herramienta detecta automáticamente el servidor de Albion mediante paquetes de red y cambia de conjunto de datos automáticamente si cambias de servidor. Los datos cargados actualmente se guardan antes de cada cambio."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Choisissez les données de serveur à charger au démarrage de l'application, avant qu'Albion Online ne soit actif. Une fois que vous jouez, l'outil détecte automatiquement le serveur Albion à partir des paquets réseau et bascule automatiquement entre les ensembles de données si vous changez de serveur. Les données actuellement chargées sont enregistrées avant chaque changement."
         },
@@ -46508,6 +48108,10 @@
         {
           "lang": "en-US",
           "seg": "Please select a startup data server."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Selecciona un servidor de datos inicial."
         },
         {
           "lang": "fr-FR",
@@ -47609,6 +49213,10 @@
           "seg": "Content"
         },
         {
+          "lang": "es-ES",
+          "seg": "Contenido"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Sommaire"
         }
@@ -47624,6 +49232,10 @@
         {
           "lang": "en-US",
           "seg": "Session"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Sesión"
         },
         {
           "lang": "fr-FR",
@@ -47643,6 +49255,10 @@
           "seg": "All content"
         },
         {
+          "lang": "es-ES",
+          "seg": "Todo el contenido"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Tout le contenu"
         }
@@ -47658,6 +49274,10 @@
         {
           "lang": "en-US",
           "seg": "All sessions"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Todas las sesiones"
         },
         {
           "lang": "fr-FR",
@@ -47677,6 +49297,10 @@
           "seg": "Corrupted Dungeon"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mazmorra corrupta"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Donjon corrompu"
         }
@@ -47692,6 +49316,10 @@
         {
           "lang": "en-US",
           "seg": "Time range"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Rango de tiempo"
         },
         {
           "lang": "fr-FR",
@@ -47711,6 +49339,10 @@
           "seg": "Reset session"
         },
         {
+          "lang": "es-ES",
+          "seg": "Reiniciar sesión"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Réinitialiser la session"
         }
@@ -47726,6 +49358,10 @@
         {
           "lang": "en-US",
           "seg": "Reset session on map change"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Reiniciar sesión al cambiar de mapa"
         },
         {
           "lang": "fr-FR",
@@ -47745,6 +49381,10 @@
           "seg": "Session time"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tiempo de sesión"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Durée de la Session"
         }
@@ -47760,6 +49400,10 @@
         {
           "lang": "en-US",
           "seg": "vs previous hour"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "vs. hora anterior"
         },
         {
           "lang": "fr-FR",
@@ -47779,6 +49423,10 @@
           "seg": "vs previous day"
         },
         {
+          "lang": "es-ES",
+          "seg": "vs. día anterior"
+        },
+        {
           "lang": "fr-FR",
           "seg": "par rapport au jour précédent"
         }
@@ -47794,6 +49442,10 @@
         {
           "lang": "en-US",
           "seg": "vs previous minutes"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "vs. minutos anteriores"
         },
         {
           "lang": "fr-FR",
@@ -47813,6 +49465,10 @@
           "seg": "vs previous hours"
         },
         {
+          "lang": "es-ES",
+          "seg": "vs. horas anteriores"
+        },
+        {
           "lang": "fr-FR",
           "seg": "par rapport aux heures précédentes"
         }
@@ -47828,6 +49484,10 @@
         {
           "lang": "en-US",
           "seg": "vs previous days"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "vs. días anteriores"
         },
         {
           "lang": "fr-FR",
@@ -47847,6 +49507,10 @@
           "seg": "Combat"
         },
         {
+          "lang": "es-ES",
+          "seg": "Combate"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Combat"
         }
@@ -47862,6 +49526,10 @@
         {
           "lang": "en-US",
           "seg": "Economy"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Economía"
         },
         {
           "lang": "fr-FR",
@@ -47881,6 +49549,10 @@
           "seg": "Delete Session"
         },
         {
+          "lang": "es-ES",
+          "seg": "Eliminar sesión"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Supprimer la Session"
         }
@@ -47896,6 +49568,10 @@
         {
           "lang": "en-US",
           "seg": "Do you want to permanently delete the session \"{0}\"?"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "¿Quieres eliminar permanentemente la sesión \"{0}\"?"
         },
         {
           "lang": "fr-FR",
@@ -47915,6 +49591,10 @@
           "seg": "The session could not be deleted."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudo eliminar la sesión."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Cette session ne peut pas $etre supprimée."
         }
@@ -47930,6 +49610,10 @@
         {
           "lang": "en-US",
           "seg": "Top Fame Sources"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Principales fuentes de fama"
         },
         {
           "lang": "fr-FR",
@@ -47949,6 +49633,10 @@
           "seg": "Top Silver Sources"
         },
         {
+          "lang": "es-ES",
+          "seg": "Principales fuentes de plata"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Principales sources de Silver"
         }
@@ -47964,6 +49652,10 @@
         {
           "lang": "en-US",
           "seg": "Silver spent on Respec"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Plata gastada en reespecialización"
         },
         {
           "lang": "fr-FR",
@@ -47983,6 +49675,10 @@
           "seg": "Average Respec silver cost per session"
         },
         {
+          "lang": "es-ES",
+          "seg": "Costo promedio de plata por reespecialización por sesión"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coût moyen en Silver d'une session de Respec"
         }
@@ -47998,6 +49694,10 @@
         {
           "lang": "en-US",
           "seg": "Respec points spent"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Puntos de reespecialización gastados"
         },
         {
           "lang": "fr-FR",
@@ -48017,6 +49717,10 @@
           "seg": "Average repair cost per session"
         },
         {
+          "lang": "es-ES",
+          "seg": "Costo promedio de reparación por sesión"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coût moyen des réparations par session"
         }
@@ -48032,6 +49736,10 @@
         {
           "lang": "en-US",
           "seg": "Highest repair cost"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mayor costo de reparación"
         },
         {
           "lang": "fr-FR",
@@ -48051,6 +49759,10 @@
           "seg": "Recently looted items"
         },
         {
+          "lang": "es-ES",
+          "seg": "Objetos saqueados recientemente"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Objets récemment pillés"
         }
@@ -48066,6 +49778,10 @@
         {
           "lang": "en-US",
           "seg": "Average loot value"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Valor promedio del botín"
         },
         {
           "lang": "fr-FR",
@@ -48085,6 +49801,10 @@
           "seg": "Top maps and loot areas by loot value"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejores mapas y zonas de botín por valor del botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleures cartes et zones de butin classées par valeur de butin"
         }
@@ -48100,6 +49820,10 @@
         {
           "lang": "en-US",
           "seg": "Refine quality"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mejorar calidad"
         },
         {
           "lang": "fr-FR",
@@ -48119,6 +49843,10 @@
           "seg": "Silver spent on refining item quality"
         },
         {
+          "lang": "es-ES",
+          "seg": "Plata gastada en mejorar la calidad de objetos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Silver dépensés pour des finitions de qualité"
         }
@@ -48134,6 +49862,10 @@
         {
           "lang": "en-US",
           "seg": "Upgraded items"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Objetos mejorados"
         },
         {
           "lang": "fr-FR",
@@ -48153,6 +49885,10 @@
           "seg": "Awaken weapon"
         },
         {
+          "lang": "es-ES",
+          "seg": "Despertar arma"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Arme éveillée"
         }
@@ -48168,6 +49904,10 @@
         {
           "lang": "en-US",
           "seg": "Silver spent on awakened weapons"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Plata gastada en armas despertadas"
         },
         {
           "lang": "fr-FR",
@@ -48187,6 +49927,10 @@
           "seg": "Traits upgraded"
         },
         {
+          "lang": "es-ES",
+          "seg": "Rasgos mejorados"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Caractéristiques améliorées"
         }
@@ -48202,6 +49946,10 @@
         {
           "lang": "en-US",
           "seg": "Upgrade procs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mejoras activadas"
         },
         {
           "lang": "fr-FR",
@@ -48221,6 +49969,10 @@
           "seg": "Loot distribution by item value"
         },
         {
+          "lang": "es-ES",
+          "seg": "Distribución del botín por valor del objeto"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Répartition du butin en fonction de la valeur des objets"
         }
@@ -48236,6 +49988,10 @@
         {
           "lang": "en-US",
           "seg": "Loot by tier and enchantment"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Botín por nivel y encantamiento"
         },
         {
           "lang": "fr-FR",
@@ -48255,6 +50011,10 @@
           "seg": "Value class (silver)"
         },
         {
+          "lang": "es-ES",
+          "seg": "Clase de valor (plata)"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Catégorie de valeur (Silver)"
         }
@@ -48270,6 +50030,10 @@
         {
           "lang": "en-US",
           "seg": "Items"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Objetos"
         },
         {
           "lang": "fr-FR",
@@ -48289,6 +50053,10 @@
           "seg": "Share of total value"
         },
         {
+          "lang": "es-ES",
+          "seg": "Porcentaje del valor total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Part de la valeur totale"
         }
@@ -48304,6 +50072,10 @@
         {
           "lang": "en-US",
           "seg": "Tier distribution"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Distribución por nivel"
         },
         {
           "lang": "fr-FR",
@@ -48323,6 +50095,10 @@
           "seg": "Enchantment"
         },
         {
+          "lang": "es-ES",
+          "seg": "Encantamiento"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Enchantement"
         }
@@ -48338,6 +50114,10 @@
         {
           "lang": "en-US",
           "seg": "Map/area"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mapa/zona"
         },
         {
           "lang": "fr-FR",
@@ -48357,6 +50137,10 @@
           "seg": "Loot value"
         },
         {
+          "lang": "es-ES",
+          "seg": "Valor del botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Valeur du butin"
         }
@@ -48372,6 +50156,10 @@
         {
           "lang": "en-US",
           "seg": "Loot/h"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Botín/h"
         },
         {
           "lang": "fr-FR",
@@ -48391,6 +50179,10 @@
           "seg": "Loot/map"
         },
         {
+          "lang": "es-ES",
+          "seg": "Botín/mapa"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Butin/map"
         }
@@ -48406,6 +50198,10 @@
         {
           "lang": "en-US",
           "seg": "Visits"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Visitas"
         },
         {
           "lang": "fr-FR",
@@ -48425,6 +50221,10 @@
           "seg": "Share"
         },
         {
+          "lang": "es-ES",
+          "seg": "Porcentaje"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Partager"
         }
@@ -48442,6 +50242,10 @@
           "seg": "Under {0:N0}"
         },
         {
+          "lang": "es-ES",
+          "seg": "Menos de {0:N0}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "En dessous de {0:N0}"
         }
@@ -48456,6 +50260,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "{0:N0} - {1:N0}"
+        },
+        {
+          "lang": "es-ES",
           "seg": "{0:N0} - {1:N0}"
         },
         {
@@ -48476,6 +50284,10 @@
           "seg": "{0:N0} - {1:N0}"
         },
         {
+          "lang": "es-ES",
+          "seg": "{0:N0} - {1:N0}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{0:N0} - {1:N0}"
         }
@@ -48491,6 +50303,10 @@
         {
           "lang": "en-US",
           "seg": "Over {0:N0}"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Más de {0:N0}"
         },
         {
           "lang": "fr-FR",
@@ -48510,6 +50326,10 @@
           "seg": "Important Loot"
         },
         {
+          "lang": "es-ES",
+          "seg": "Botín importante"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Butin important"
         }
@@ -48525,6 +50345,10 @@
         {
           "lang": "en-US",
           "seg": "Monitoring"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Seguimiento"
         },
         {
           "lang": "fr-FR",
@@ -48544,6 +50368,10 @@
           "seg": "Monitor this item and receive a one-time notification when a condition is met."
         },
         {
+          "lang": "es-ES",
+          "seg": "Supervisa este objeto y recibe una notificación única cuando se cumpla una condición."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Suivez cet article et recevez une notification unique lorsqu'une condition sera remplie."
         }
@@ -48559,6 +50387,10 @@
         {
           "lang": "en-US",
           "seg": "Price monitoring"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Seguimiento de precio"
         },
         {
           "lang": "fr-FR",
@@ -48578,6 +50410,10 @@
           "seg": "Notifies you when a current sell offer reaches or falls below the configured price."
         },
         {
+          "lang": "es-ES",
+          "seg": "Te notifica cuando una oferta de venta actual alcanza o baja del precio configurado."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Vous avertit lorsqu'une offre de vente en cours atteint ou passe en dessous du prix défini."
         }
@@ -48593,6 +50429,10 @@
         {
           "lang": "en-US",
           "seg": "Price limit"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Límite de precio"
         },
         {
           "lang": "fr-FR",
@@ -48612,6 +50452,10 @@
           "seg": "Market availability"
         },
         {
+          "lang": "es-ES",
+          "seg": "Disponibilidad en el mercado"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Disponibilité sur le marché"
         }
@@ -48627,6 +50471,10 @@
         {
           "lang": "en-US",
           "seg": "Notifies you as soon as a current sell offer for this item is reported."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Te notifica en cuanto se informa de una oferta de venta actual para este objeto."
         },
         {
           "lang": "fr-FR",
@@ -48646,6 +50494,10 @@
           "seg": "Play alert sound"
         },
         {
+          "lang": "es-ES",
+          "seg": "Reproducir sonido de alerta"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Lire le son d'alerte"
         }
@@ -48661,6 +50513,10 @@
         {
           "lang": "en-US",
           "seg": "Enter a valid price limit greater than 0."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Introduce un límite de precio válido mayor que 0."
         },
         {
           "lang": "fr-FR",
@@ -48680,6 +50536,10 @@
           "seg": "A maximum of 10 items can be monitored at the same time."
         },
         {
+          "lang": "es-ES",
+          "seg": "Se pueden supervisar como máximo 10 objetos al mismo tiempo."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Il est possible de surveiller jusqu'à 10 éléments simultanément."
         }
@@ -48695,6 +50555,10 @@
         {
           "lang": "en-US",
           "seg": "Monitoring could not be activated for this item."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "No se pudo activar el seguimiento para este objeto."
         },
         {
           "lang": "fr-FR",
@@ -48714,6 +50578,10 @@
           "seg": "Market offer found"
         },
         {
+          "lang": "es-ES",
+          "seg": "Oferta de mercado encontrada"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Offre trouvée sur le marché"
         }
@@ -48729,6 +50597,10 @@
         {
           "lang": "en-US",
           "seg": "A market offer for"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Una oferta de mercado para"
         },
         {
           "lang": "fr-FR",
@@ -48748,6 +50620,10 @@
           "seg": "was found."
         },
         {
+          "lang": "es-ES",
+          "seg": "fue encontrada."
+        },
+        {
           "lang": "fr-FR",
           "seg": "a été retrouvé."
         }
@@ -48763,6 +50639,10 @@
         {
           "lang": "en-US",
           "seg": "Maximum price age"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Antigüedad máxima del precio"
         },
         {
           "lang": "fr-FR",
@@ -48782,6 +50662,10 @@
           "seg": "Only prices reported within this many minutes can trigger an alert."
         },
         {
+          "lang": "es-ES",
+          "seg": "Solo los precios informados dentro de esta cantidad de minutos pueden activar una alerta."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Seuls les prix dont la dernière mise à jour remonte à un nombre de minutes au plus égal à cette valeur peuvent déclencher une alerte."
         }
@@ -48797,6 +50681,10 @@
         {
           "lang": "en-US",
           "seg": "Enter a maximum price age of at least one minute."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Introduce una antigüedad máxima del precio de al menos un minuto."
         },
         {
           "lang": "fr-FR",
@@ -48816,6 +50704,10 @@
           "seg": "Monitor Black Market buy order"
         },
         {
+          "lang": "es-ES",
+          "seg": "Supervisar orden de compra del Mercado Negro"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Surveiller les ordres d'achat sur le marché noir"
         }
@@ -48831,6 +50723,10 @@
         {
           "lang": "en-US",
           "seg": "Notifies you when the highest reported Black Market buy order reaches or exceeds the specified minimum price."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Te notifica cuando la orden de compra más alta informada en el Mercado Negro alcanza o supera el precio mínimo especificado."
         },
         {
           "lang": "fr-FR",
@@ -48850,6 +50746,10 @@
           "seg": "Minimum buy order price"
         },
         {
+          "lang": "es-ES",
+          "seg": "Precio mínimo de la orden de compra"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prix minimum de l'ordre d'achat"
         }
@@ -48865,6 +50765,10 @@
         {
           "lang": "en-US",
           "seg": "This item cannot be sold on the Black Market."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Este objeto no se puede vender en el Mercado Negro."
         },
         {
           "lang": "fr-FR",
@@ -48884,6 +50788,10 @@
           "seg": "Black Market buy order reached"
         },
         {
+          "lang": "es-ES",
+          "seg": "Orden de compra del Mercado Negro alcanzada"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ordre d'achat sur le marché noir reçu"
         }
@@ -48899,6 +50807,10 @@
         {
           "lang": "en-US",
           "seg": "The highest Black Market buy order for"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "La orden de compra más alta del Mercado Negro para"
         },
         {
           "lang": "fr-FR",
@@ -48918,6 +50830,10 @@
           "seg": "has reached your minimum price."
         },
         {
+          "lang": "es-ES",
+          "seg": "ha alcanzado tu precio mínimo."
+        },
+        {
           "lang": "fr-FR",
           "seg": "a atteint ton prix minimum."
         }
@@ -48933,6 +50849,10 @@
         {
           "lang": "en-US",
           "seg": "Search"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Buscar"
         },
         {
           "lang": "fr-FR",
@@ -48952,6 +50872,10 @@
           "seg": "Locations"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ubicaciones"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Lieux"
         }
@@ -48967,6 +50891,10 @@
         {
           "lang": "en-US",
           "seg": "Trading Activity by Location"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Actividad comercial por ubicación"
         },
         {
           "lang": "fr-FR",
@@ -48986,6 +50914,10 @@
           "seg": "Sales"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ventas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ventes"
         }
@@ -49001,6 +50933,10 @@
         {
           "lang": "en-US",
           "seg": "Purchases"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Compras"
         },
         {
           "lang": "fr-FR",
@@ -49020,6 +50956,10 @@
           "seg": "Count"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cantidad"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nombre"
         }
@@ -49035,6 +50975,10 @@
         {
           "lang": "en-US",
           "seg": "Margin"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Margen"
         },
         {
           "lang": "fr-FR",
@@ -49054,6 +50998,10 @@
           "seg": "Tax paid"
         },
         {
+          "lang": "es-ES",
+          "seg": "Impuesto pagado"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Taxes payées"
         }
@@ -49069,6 +51017,10 @@
         {
           "lang": "en-US",
           "seg": "Most traded category"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Categoría más negociada"
         },
         {
           "lang": "fr-FR",
@@ -49088,6 +51040,10 @@
           "seg": "Reset filters"
         },
         {
+          "lang": "es-ES",
+          "seg": "Restablecer filtros"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Réinitialiser les filtres"
         }
@@ -49103,6 +51059,10 @@
         {
           "lang": "en-US",
           "seg": "Total sales"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Ventas totales"
         },
         {
           "lang": "fr-FR",
@@ -49122,6 +51082,10 @@
           "seg": "Total purchases"
         },
         {
+          "lang": "es-ES",
+          "seg": "Compras totales"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Achats totaux"
         }
@@ -49137,6 +51101,10 @@
         {
           "lang": "en-US",
           "seg": "Trade volume"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Volumen de comercio"
         },
         {
           "lang": "fr-FR",
@@ -49156,6 +51124,10 @@
           "seg": "Trade statistics"
         },
         {
+          "lang": "es-ES",
+          "seg": "Estadísticas de comercio"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Statistiques commerciales"
         }
@@ -49171,6 +51143,10 @@
         {
           "lang": "en-US",
           "seg": "Compared with the previous period"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Comparado con el período anterior"
         },
         {
           "lang": "fr-FR",
@@ -49190,6 +51166,10 @@
           "seg": "Overview"
         },
         {
+          "lang": "es-ES",
+          "seg": "Resumen"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Aperçu"
         }
@@ -49205,6 +51185,10 @@
         {
           "lang": "en-US",
           "seg": "Best resource"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mejor recurso"
         },
         {
           "lang": "fr-FR",
@@ -49224,6 +51208,10 @@
           "seg": "Top map"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejor mapa"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleure carte"
         }
@@ -49239,6 +51227,10 @@
         {
           "lang": "en-US",
           "seg": "Unique resource types"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tipos de recursos únicos"
         },
         {
           "lang": "fr-FR",
@@ -49258,6 +51250,10 @@
           "seg": "Best gathering map"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejor mapa de recolección"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleure carte de récolte"
         }
@@ -49273,6 +51269,10 @@
         {
           "lang": "en-US",
           "seg": "Total resources gathered"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Total de recursos recolectados"
         },
         {
           "lang": "fr-FR",
@@ -49292,6 +51292,10 @@
           "seg": "Total gathering processes"
         },
         {
+          "lang": "es-ES",
+          "seg": "Total de procesos de recolección"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Total des récoltes"
         }
@@ -49307,6 +51311,10 @@
         {
           "lang": "en-US",
           "seg": "Average resource value"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Valor promedio de los recursos"
         },
         {
           "lang": "fr-FR",
@@ -49326,6 +51334,10 @@
           "seg": "Best single gathering"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejor recolección individual"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleure récolte individuelle"
         }
@@ -49341,6 +51353,10 @@
         {
           "lang": "en-US",
           "seg": "Times gathered"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Veces recolectado"
         },
         {
           "lang": "fr-FR",
@@ -49360,6 +51376,10 @@
           "seg": "Total amount"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cantidad total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Quantité totale"
         }
@@ -49375,6 +51395,10 @@
         {
           "lang": "en-US",
           "seg": "Total value"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Valor total"
         },
         {
           "lang": "fr-FR",
@@ -49394,6 +51418,10 @@
           "seg": "Average value per gather"
         },
         {
+          "lang": "es-ES",
+          "seg": "Valor promedio por recolección"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Valeur moyenne par récolte"
         }
@@ -49409,6 +51437,10 @@
         {
           "lang": "en-US",
           "seg": "Gathering time"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tiempo de recolección"
         },
         {
           "lang": "fr-FR",
@@ -49428,6 +51460,10 @@
           "seg": "Resource value by type"
         },
         {
+          "lang": "es-ES",
+          "seg": "Valor de recursos por tipo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Valeur des ressources par type"
         }
@@ -49443,6 +51479,10 @@
         {
           "lang": "en-US",
           "seg": "Gathering activity over time"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Actividad de recolección a lo largo del tiempo"
         },
         {
           "lang": "fr-FR",
@@ -49462,6 +51502,10 @@
           "seg": "Gathering activity by location"
         },
         {
+          "lang": "es-ES",
+          "seg": "Actividad de recolección por ubicación"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Activité de récolte par lieu"
         }
@@ -49477,6 +51521,10 @@
         {
           "lang": "en-US",
           "seg": "Resource types gathered"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tipos de recursos recolectados"
         },
         {
           "lang": "fr-FR",
@@ -49496,6 +51544,10 @@
           "seg": "Top gathered resources"
         },
         {
+          "lang": "es-ES",
+          "seg": "Recursos más recolectados"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Ressources les plus récoltées"
         }
@@ -49511,6 +51563,10 @@
         {
           "lang": "en-US",
           "seg": "Recent gatherings"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Recolecciones recientes"
         },
         {
           "lang": "fr-FR",
@@ -49530,6 +51586,10 @@
           "seg": "Resource type"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tipo de recurso"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Type de la ressource"
         }
@@ -49545,6 +51605,10 @@
         {
           "lang": "en-US",
           "seg": "Amount"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cantidad"
         },
         {
           "lang": "fr-FR",
@@ -49564,6 +51628,10 @@
           "seg": "% of total"
         },
         {
+          "lang": "es-ES",
+          "seg": "% del total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "% du total"
         }
@@ -49579,6 +51647,10 @@
         {
           "lang": "en-US",
           "seg": "Map"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mapa"
         },
         {
           "lang": "fr-FR",
@@ -49598,6 +51670,10 @@
           "seg": "No data"
         },
         {
+          "lang": "es-ES",
+          "seg": "Sin datos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Pas de données"
         }
@@ -49613,6 +51689,10 @@
         {
           "lang": "en-US",
           "seg": "Other maps"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Otros mapas"
         },
         {
           "lang": "fr-FR",
@@ -49632,6 +51712,10 @@
           "seg": "Run efficiency"
         },
         {
+          "lang": "es-ES",
+          "seg": "Eficiencia de las partidas"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Efficacité de run"
         }
@@ -49647,6 +51731,10 @@
         {
           "lang": "en-US",
           "seg": "Total runs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Total de partidas"
         },
         {
           "lang": "fr-FR",
@@ -49666,6 +51754,10 @@
           "seg": "Total Might"
         },
         {
+          "lang": "es-ES",
+          "seg": "Poder total"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Puissance totale"
         }
@@ -49681,6 +51773,10 @@
         {
           "lang": "en-US",
           "seg": "Total Favor"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Favor total"
         },
         {
           "lang": "fr-FR",
@@ -49700,6 +51796,10 @@
           "seg": "Deaths in dungeons"
         },
         {
+          "lang": "es-ES",
+          "seg": "Muertes en mazmorras"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Morts en donjons"
         }
@@ -49715,6 +51815,10 @@
         {
           "lang": "en-US",
           "seg": "Average run time"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Duración promedio de la partida"
         },
         {
           "lang": "fr-FR",
@@ -49734,6 +51838,10 @@
           "seg": "Most profitable tier"
         },
         {
+          "lang": "es-ES",
+          "seg": "Nivel más rentable"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Tiers le plus rentable"
         }
@@ -49749,6 +51857,10 @@
         {
           "lang": "en-US",
           "seg": "Most played tier"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Nivel más jugado"
         },
         {
           "lang": "fr-FR",
@@ -49768,6 +51880,10 @@
           "seg": "Best dungeon map"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejor mapa de mazmorra"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Meilleure carte de donjon"
         }
@@ -49783,6 +51899,10 @@
         {
           "lang": "en-US",
           "seg": "Fastest run"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Partida más rápida"
         },
         {
           "lang": "fr-FR",
@@ -49802,6 +51922,10 @@
           "seg": "Average chests / Run"
         },
         {
+          "lang": "es-ES",
+          "seg": "Promedio de cofres / partida"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Moyenne de coffre / Run"
         }
@@ -49817,6 +51941,10 @@
         {
           "lang": "en-US",
           "seg": "Average loot / run"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Promedio de botín / partida"
         },
         {
           "lang": "fr-FR",
@@ -49836,6 +51964,10 @@
           "seg": "Average Fame / run"
         },
         {
+          "lang": "es-ES",
+          "seg": "Promedio de fama / partida"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Moyenne de Fame / Run"
         }
@@ -49851,6 +51983,10 @@
         {
           "lang": "en-US",
           "seg": "Average duration"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Duración promedio"
         },
         {
           "lang": "fr-FR",
@@ -49870,6 +52006,10 @@
           "seg": "Party size"
         },
         {
+          "lang": "es-ES",
+          "seg": "Tamaño del grupo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Taille de la partie"
         }
@@ -49885,6 +52025,10 @@
         {
           "lang": "en-US",
           "seg": "Content runs"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Partidas de contenido"
         },
         {
           "lang": "fr-FR",
@@ -49904,6 +52048,10 @@
           "seg": "{0} loot entries"
         },
         {
+          "lang": "es-ES",
+          "seg": "{0} entradas de botín"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{0} objets de butin"
         }
@@ -49919,6 +52067,10 @@
         {
           "lang": "en-US",
           "seg": "Show collected loot"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mostrar botín recogido"
         },
         {
           "lang": "fr-FR",
@@ -49938,6 +52090,10 @@
           "seg": "Hide collected loot"
         },
         {
+          "lang": "es-ES",
+          "seg": "Ocultar botín recogido"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Cacher le butin ramassé"
         }
@@ -49952,6 +52108,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "Avalon"
+        },
+        {
+          "lang": "es-ES",
           "seg": "Avalon"
         },
         {
@@ -49972,6 +52132,10 @@
           "seg": "Unknown chest"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cofre desconocido"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coffre inconnu"
         }
@@ -49987,6 +52151,10 @@
         {
           "lang": "en-US",
           "seg": "Dungeon Overview"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Resumen de mazmorra"
         },
         {
           "lang": "fr-FR",
@@ -50006,6 +52174,10 @@
           "seg": "Include player loot"
         },
         {
+          "lang": "es-ES",
+          "seg": "Incluir botín de jugadores"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Prendre en compte le butin des joueurs"
         }
@@ -50023,6 +52195,10 @@
           "seg": "Chest"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cofre"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coffre"
         }
@@ -50037,6 +52213,10 @@
         },
         {
           "lang": "en-US",
+          "seg": "Mob"
+        },
+        {
+          "lang": "es-ES",
           "seg": "Mob"
         },
         {
@@ -50057,6 +52237,10 @@
           "seg": "Player"
         },
         {
+          "lang": "es-ES",
+          "seg": "Jugador"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Joueur"
         }
@@ -50072,6 +52256,10 @@
         {
           "lang": "en-US",
           "seg": "Unknown source"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Fuente desconocida"
         },
         {
           "lang": "fr-FR",
@@ -50091,6 +52279,10 @@
           "seg": "Settings and Reset"
         },
         {
+          "lang": "es-ES",
+          "seg": "Configuración y reinicio"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Paramètres et Réinitialisation"
         }
@@ -50106,6 +52298,10 @@
         {
           "lang": "en-US",
           "seg": "Other loot"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Otro botín"
         },
         {
           "lang": "fr-FR",
@@ -50125,6 +52321,10 @@
           "seg": "+{0} more chests"
         },
         {
+          "lang": "es-ES",
+          "seg": "+{0} cofres más"
+        },
+        {
           "lang": "fr-FR",
           "seg": "+{0} autres coffres"
         }
@@ -50140,6 +52340,10 @@
         {
           "lang": "en-US",
           "seg": "Show fewer"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mostrar menos"
         },
         {
           "lang": "fr-FR",
@@ -50159,6 +52363,10 @@
           "seg": "Brecilian standing"
         },
         {
+          "lang": "es-ES",
+          "seg": "Reputación de Brecilien"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Brecilien - Vue d'ensemble"
         }
@@ -50174,6 +52382,10 @@
         {
           "lang": "en-US",
           "seg": "Players"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Jugadores"
         },
         {
           "lang": "fr-FR",
@@ -50193,6 +52405,10 @@
           "seg": "Normal chest"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cofre normal"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Coffre normal"
         }
@@ -50208,6 +52424,10 @@
         {
           "lang": "en-US",
           "seg": "+{0} more items"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "+{0} objetos más"
         },
         {
           "lang": "fr-FR",
@@ -50227,6 +52447,10 @@
           "seg": "Show fewer items"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mostrar menos objetos"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Monter moins d'objets"
         }
@@ -50242,6 +52466,10 @@
         {
           "lang": "en-US",
           "seg": "+{0} more kills/deaths"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "+{0} asesinatos/muertes más"
         },
         {
           "lang": "fr-FR",
@@ -50261,6 +52489,10 @@
           "seg": "Show fewer kills/deaths"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mostrar menos asesinatos/muertes"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Afficher moins de victimes/morts"
         }
@@ -50276,6 +52508,10 @@
         {
           "lang": "en-US",
           "seg": "Total Damage – TOP 5"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño total – TOP 5"
         },
         {
           "lang": "fr-FR",
@@ -50295,6 +52531,10 @@
           "seg": "Effective Healing – TOP 5"
         },
         {
+          "lang": "es-ES",
+          "seg": "Curación efectiva – TOP 5"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Efficacité des Soins – TOP 5"
         }
@@ -50310,6 +52550,10 @@
         {
           "lang": "en-US",
           "seg": "Top Mob Kill Contribution – TOP 5"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mayor contribución a muertes de mobs – TOP 5"
         },
         {
           "lang": "fr-FR",
@@ -50329,6 +52573,10 @@
           "seg": "Top Healer"
         },
         {
+          "lang": "es-ES",
+          "seg": "Mejor sanador"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Top Healer"
         }
@@ -50344,6 +52592,10 @@
         {
           "lang": "en-US",
           "seg": "Top Damage Taken"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Mayor daño recibido"
         },
         {
           "lang": "fr-FR",
@@ -50363,6 +52615,10 @@
           "seg": "Damage by Type"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño por tipo"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dégâts par type"
         }
@@ -50378,6 +52634,10 @@
         {
           "lang": "en-US",
           "seg": "Damage by Ability – Top 10"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño por habilidad – Top 10"
         },
         {
           "lang": "fr-FR",
@@ -50397,6 +52657,10 @@
           "seg": "Ability"
         },
         {
+          "lang": "es-ES",
+          "seg": "Habilidad"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Capacités"
         }
@@ -50412,6 +52676,10 @@
         {
           "lang": "en-US",
           "seg": "Physical Damage"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño físico"
         },
         {
           "lang": "fr-FR",
@@ -50431,6 +52699,10 @@
           "seg": "Magic Damage"
         },
         {
+          "lang": "es-ES",
+          "seg": "Daño mágico"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Dégâts magiques"
         }
@@ -50446,6 +52718,10 @@
         {
           "lang": "en-US",
           "seg": "True Damage"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Daño verdadero"
         },
         {
           "lang": "fr-FR",
@@ -50465,6 +52741,10 @@
           "seg": "Total Tracked Fights"
         },
         {
+          "lang": "es-ES",
+          "seg": "Total de combates rastreados"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Nombre total de combats recensés"
         }
@@ -50480,6 +52760,10 @@
         {
           "lang": "en-US",
           "seg": "Loss Explorer"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Explorador de pérdidas"
         },
         {
           "lang": "fr-FR",
@@ -50499,6 +52783,10 @@
           "seg": "Equipment"
         },
         {
+          "lang": "es-ES",
+          "seg": "Equipamiento"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Equipment"
         }
@@ -50514,6 +52802,10 @@
         {
           "lang": "en-US",
           "seg": "Inventory"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Inventario"
         },
         {
           "lang": "fr-FR",
@@ -50533,6 +52825,10 @@
           "seg": "Loading deaths – page {0}"
         },
         {
+          "lang": "es-ES",
+          "seg": "Cargando muertes – página {0}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "Chargement des morts – page {0}"
         }
@@ -50548,6 +52844,10 @@
         {
           "lang": "en-US",
           "seg": "Loading market values – batch {0} of {1}"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Cargando valores de mercado – lote {0} de {1}"
         },
         {
           "lang": "fr-FR",
@@ -50567,6 +52867,10 @@
           "seg": "{0:N0} of 7 days stored · daily average · updated {1:g}"
         },
         {
+          "lang": "es-ES",
+          "seg": "{0:N0} de 7 días almacenados · promedio diario · actualizado {1:g}"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{0:N0} sur 7 jours · moyenne quotidienne · mise à jour {1:g}"
         }
@@ -50582,6 +52886,10 @@
         {
           "lang": "en-US",
           "seg": "Loss data is updated every 10 minutes and stored for up to 7 days."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Los datos de pérdidas se actualizan cada 10 minutos y se almacenan hasta por 7 días."
         },
         {
           "lang": "fr-FR",
@@ -50601,6 +52909,10 @@
           "seg": "Loss data could not be loaded completely. The next automatic refresh will retry."
         },
         {
+          "lang": "es-ES",
+          "seg": "No se pudieron cargar completamente los datos de pérdidas. La próxima actualización automática volverá a intentarlo."
+        },
+        {
           "lang": "fr-FR",
           "seg": "Les données relatives aux pertes n'ont pas pu être chargées dans leur intégralité. La prochaine synchronisation automatique effectuera une nouvelle tentative."
         }
@@ -50616,6 +52928,10 @@
         {
           "lang": "en-US",
           "seg": "An Albion server must be active to use the Loss Explorer."
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Debe haber un servidor de Albion activo para usar el Explorador de pérdidas."
         },
         {
           "lang": "fr-FR",
@@ -50635,6 +52951,10 @@
           "seg": "{0:N0} events stored"
         },
         {
+          "lang": "es-ES",
+          "seg": "{0:N0} eventos almacenados"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{0:N0} événements enregistrés"
         }
@@ -50650,6 +52970,10 @@
         {
           "lang": "en-US",
           "seg": "{0:N0} / day"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "{0:N0} / día"
         },
         {
           "lang": "fr-FR",
@@ -50669,6 +52993,10 @@
           "seg": "({0:N0} per item)"
         },
         {
+          "lang": "es-ES",
+          "seg": "({0:N0} por objeto)"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{0:N0} par objet"
         }
@@ -50686,6 +53014,10 @@
           "seg": "{0:N0} lost items / day"
         },
         {
+          "lang": "es-ES",
+          "seg": "{0:N0} objetos perdidos / día"
+        },
+        {
           "lang": "fr-FR",
           "seg": "{0:N0} objets perdus / jour"
         }
@@ -50701,6 +53033,10 @@
         {
           "lang": "en-US",
           "seg": "Server Type"
+        },
+        {
+          "lang": "es-ES",
+          "seg": "Tipo de servidor"
         },
         {
           "lang": "fr-FR",


### PR DESCRIPTION
## Checklist

- [x] This is not a **duplicate** of an existing merge request.
- [x] I believe this falls into the scope of the project and should be part of the built-in functionality.
- [ ] All new and existing tests pass.

## Changes

### New functionality

No new functionality.

### Changed functionality

- Completes the Spanish (`es-ES`) localization by adding 585 missing translations.
- Brings Spanish localization coverage to 1,305 / 1,305 current English entries (100%).
- Removes a duplicate `es-ES` entry in `ITEM_SEARCH`, keeping `Buscar objeto`.
- Preserves existing placeholders and localization structure.

### Removed functionality

No functionality removed.

## Additional info

The localization JSON was validated after the changes, including checks that placeholders used by the English source strings are preserved in the Spanish translations. The full application test suite was not run, so that checklist item is intentionally left unchecked.